### PR TITLE
fix for Issue #161

### DIFF
--- a/client.py
+++ b/client.py
@@ -349,7 +349,7 @@ def filter_git_commit_data(repository_name, repository_team, repository_type, fo
                     number += 1
                     each_commit.update({int(number): get_commit_details(commit)})
                     new_commit_dict.update(each_commit)
-            json_writer_git(repository_name, new_commit_dict)
+        json_writer_git(repository_name, new_commit_dict)
         return True
     # TYPE = TAG
     if repository_type == "tag" and repository_name == "build-puppet":


### PR DESCRIPTION
This PR will:
- Fix the issue that returns the last deployed commit for each commit that was not deployed. Issue #161
-- this change makes the script to send the list with all the new deployed commits, not with the commits one by one