### PR TITLE
Solve HG generation bug, update click

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Absolutely! Please [Open an Issue, or more](https://github.com/Akhliskun/firefox
 # Flags
 | | |
 |--------|----------------------------------------------------------------------------|
+| --all  | Runs script for all available repositories
 | --git  | Runs script only for repos that are on GitHub                              |
 | --hg   | Runs script only for repos that are on Mercurial                           |
 | --r    | Let the user choose for which repositories the script will run             |

--- a/client.py
+++ b/client.py
@@ -13,24 +13,33 @@ from fic_modules.configuration import (
 from fic_modules.markdown_modules import generate_main_md_table
 
 
-@click.command()
-@click.option('--git', flag_value='git', help='Run script only for GIT repos')
-@click.option('--hg', flag_value='hg', help='Run script only for HG repos')
+@click.group()
+def cli():
+    """Firefox-Infra-Changelog: tool which build a
+    changelog of commits happening on git or hg that
+    could affect Firefox CI Infra"""
+    pass
+
+
+@cli.command()
+@click.option('--all', flag_value='a',
+              help='Run for all currently available repositories')
+@click.option('--git', flag_value='git', help='Run only for GIT repos')
+@click.option('--hg', flag_value='hg', help='Run only for HG repos')
 @click.option('--l', flag_value='l', help='Display logger')
 @click.option('--r', flag_value='r',
               help='Let you choose for which repositories the script will run')
-def cli(git, hg, l, r):
+def cli(all, git, hg, l, r):
     """
-
-    :param git: Runs the script only for GIT repositories
-    :param hg: Runs the script only for HG repositories
-    :param l: Display logger
-    :param r: Let you choose for which repositories the script will run
-    :param d: Let you choose the amount of days the main markdown file will
-    contain
-    :return:
-    """
-
+    Firefox-Infra-Changelog: tool which build a
+    changelog of commits happening on git or hg that
+    could affect Firefox CI Infra"""
+    if all:
+        create_files_for_git(REPOSITORIES, onerepo=False)
+        create_files_for_hg(REPOSITORIES, onerepo=False)
+        clear_file("changelog.md", GENERATE_FOR_X_DAYS)
+        generate_main_md_table("hg_files", GENERATE_FOR_X_DAYS)
+        generate_main_md_table("git_files", GENERATE_FOR_X_DAYS)
     if git:
         create_files_for_git(REPOSITORIES, onerepo=False)
         clear_file("changelog.md", GENERATE_FOR_X_DAYS)
@@ -85,13 +94,6 @@ def cli(git, hg, l, r):
                     REPO_LIST.pop(int(new_entry))
             except ValueError:
                 exit(0)
-
-    else:
-        create_files_for_git(REPOSITORIES, onerepo=False)
-        create_files_for_hg(REPOSITORIES, onerepo=False)
-        clear_file("changelog.md", GENERATE_FOR_X_DAYS)
-        generate_main_md_table("hg_files", GENERATE_FOR_X_DAYS)
-        generate_main_md_table("git_files", GENERATE_FOR_X_DAYS)
 
 
 if __name__ == "__main__":

--- a/fic_modules/configuration.py
+++ b/fic_modules/configuration.py
@@ -14,6 +14,7 @@ TOKEN = os.environ.get("GIT_TOKEN")
 GIT = Github(TOKEN)
 REPO_CHOICE = "ALL"
 GENERATE_FOR_X_DAYS = int(1)
+NUMBER_OF_CHANGESETS = int(100)
 REPO_LIST = []
 LAST_WEEK = datetime.now() - timedelta(days=14)
 LAST_MONTH = datetime.utcnow() - timedelta(days=31)

--- a/fic_modules/helper_functions.py
+++ b/fic_modules/helper_functions.py
@@ -1,10 +1,11 @@
 import re
 import sys
-import os
-from github import Github, GithubException
+from github import GithubException
 from fic_modules.configuration import (
     REPOSITORIES,
-    REPO_LIST
+    REPO_LIST,
+    TOKEN,
+    GIT
 )
 from datetime import datetime
 
@@ -22,7 +23,6 @@ def compare_files(first_list, second_list):
         for element_s in range(len(second_list)):
             if str(second_list[element_s]) in str(first_list[element_f]):
                 return True
-    return False
 
 
 def clear_file(file_name, generated_for_days=1):
@@ -183,8 +183,6 @@ def limit_checker():
     to pass.
     :return: returns 1 if your limit requests is not exceeded
     """
-    TOKEN = os.environ.get("GIT_TOKEN")
-    GIT = Github(TOKEN)
     rate_limit = GIT.rate_limiting[0]
     unix_reset_time = GIT.rate_limiting_resettime
     reset_time = datetime.fromtimestamp(unix_reset_time)
@@ -210,12 +208,11 @@ def limit_checker():
 
 def get_keys(name):
     """
-    :param name:
-    :return:
+    :param name: Name of the platform
+    :return: A list with all available repositories
     """
     for key in REPOSITORIES.get("{}".format(name)):
         REPO_LIST.append(key)
-    print(REPO_LIST)
     return REPO_LIST
 
 

--- a/fic_modules/hg.py
+++ b/fic_modules/hg.py
@@ -9,7 +9,8 @@ from datetime import (
 from fic_modules.configuration import (
     REPOSITORIES,
     LOGGER,
-    WORKING_DIR
+    WORKING_DIR,
+    NUMBER_OF_CHANGESETS
 )
 from fic_modules.helper_functions import (
     remove_chars,
@@ -48,7 +49,9 @@ def generate_hg_pushes_link(repo_name, repository_url):
     data = json.loads(response.read())
     end_id = data.get("lastpushid")
     if start_id == 0:
-        start_id = end_id - 100
+        start_id = end_id - NUMBER_OF_CHANGESETS
+        if end_id < 100:
+            start_id = 1
     start_id = str(start_id)
     end_id = str(end_id)
     generate_pushes_link = repository_url + "json-pushes?version=2&" \
@@ -152,13 +155,8 @@ def filter_hg_commit_data(repository_name, folders_to_check, repository_url):
                             "commiter_name": author,
                             "commit_message": desc,
                             "files_changed": files_changed}})
-            else:
-                hg_repo_data[number]["changeset_commits"].update({
-                    counter2: {
-                        "url": url,
-                        "commiter_name": author,
-                        "commit_message": desc,
-                        "files_changed": files_changed}})
+        if hg_repo_data[number].get('changeset_commits') == {}:
+            hg_repo_data.pop(number)
     json_writer_hg(repository_name, hg_repo_data)
 
 
@@ -174,24 +172,27 @@ def json_writer_hg(repository_name, new_commits):
                 commit_json:
             # loads the content of existing json into a variable
             json_content = json.load(commit_json)
+            number = len(json_content) - 1
+            if json_content['0']:
+                json_content['0'].update(new_commits['0'])
+            if len(new_commits) > 1:
+                for commit in new_commits:
+                    if commit != new_commits[0]:
+                        json_content.update({int(number): commit})
+                        number += 1
+            json_file = open(WORKING_DIR + "/hg_files/" + hg_json_filename, "w")
+            json.dump(json_content, json_file, indent=2)
+            json_file.close()
     except FileNotFoundError:
-        json_content = ""
-    # if len(json_content) > 0:
-    number = len(json_content) - 1
-    for new_commit in new_commits:
-        if new_commit == "0":
-            json_content["0"] = new_commits[new_commit]
-        else:
-            # if len(new_commits[new_commit].get("changeset_commits")) != 0:
-            if new_commits[new_commit].get("changeset_commits"):
-                number += 1
-                json_content.update({int(number): new_commits[new_commit]})
-
-    # if len(new_commits) > 0:
-    if new_commits:
+        json_content = {}
+        number = 0
+        for commit in new_commits:
+            json_content.update({int(number): new_commits[commit]})
+            number += 1
         json_file = open(WORKING_DIR + "/hg_files/" + hg_json_filename, "w")
         json.dump(json_content, json_file, indent=2)
         json_file.close()
+
 
 
 def extract_json_from_hg(json_files, path_to_files, days_to_generate):

--- a/fic_modules/hg.py
+++ b/fic_modules/hg.py
@@ -177,8 +177,8 @@ def json_writer_hg(repository_name, new_commits):
                 json_content['0'].update(new_commits['0'])
             if len(new_commits) > 1:
                 for commit in new_commits:
-                    if commit != new_commits[0]:
-                        json_content.update({int(number): commit})
+                    if commit != '0':
+                        json_content.update({int(number): new_commits[commit]})
                         number += 1
             json_file = open(WORKING_DIR + "/hg_files/" + hg_json_filename, "w")
             json.dump(json_content, json_file, indent=2)

--- a/fic_modules/hg.py
+++ b/fic_modules/hg.py
@@ -194,7 +194,6 @@ def json_writer_hg(repository_name, new_commits):
         json_file.close()
 
 
-
 def extract_json_from_hg(json_files, path_to_files, days_to_generate):
     """
     Extracts the json data from json files and writes the data to the main

--- a/fic_modules/markdown_modules.py
+++ b/fic_modules/markdown_modules.py
@@ -214,7 +214,7 @@ def create_hg_md_table(repository_name):
 
         for key in data:
             if key > "0":
-                key = str(len(data) - int(key))
+                #key = str(len(data) - int(key))
                 changeset_id = data.get(key).get("changeset_number")
                 date_of_push = data.get(key).get("date_of_push")
                 try:

--- a/repositories.json
+++ b/repositories.json
@@ -168,7 +168,10 @@
         " "
       ],
       "configuration": {
-        "folders-to-check": [],
+        "folders-to-check": [
+          "projects.yml",
+          "grants.yml"
+      ],
         "push_type": "json-log"
       }
     },
@@ -181,7 +184,10 @@
         " "
       ],
       "configuration": {
-        "folders-to-check": [],
+        "folders-to-check": [
+          "ciadmin/",
+          "tests"
+      ],
         "push_type": "json-log"
       }
      }


### PR DESCRIPTION
Modified the following:

* Solved bugs in HG generation process . It used to bring blank changesets. (Changesets that do not contain files we care about when there weren't any .json files generated)
* Update readme.md
* Update configuration.py
* Modified HG generation process
* Update @click part in client.py
* In case we'll have to delete .json files (hard reset), the script will successfully generate new ones
* Add NUMBER_OF_CHANGESETS in configuration.py. This variable is used only when there aren't any hg json files generated. Basically, by modifying this variable , script will generate json/md files for the last number of changesets
* WORKING_DIR is used to step back a folder from /fic_modules to /firefox-infra-changelog. Used because git.py and hg.py are in fic_modules/.
* You might see strange import inside functions. For example , search for create_files_for_hg in hg.py. Those were used there because of the circular imports.