### PR TITLE
Issue 236: Handle unknown arguments

### DIFF
--- a/client.py
+++ b/client.py
@@ -121,7 +121,7 @@ def cli(complete=False, git=False, mercurial=False, logger=False, manual=False,
     generated for
     :return:
     """
-    valid_args = ['-d', '--days', '-g', '--git', '-h', '--hg', '-l',
+    valid_args = ['-d', '--days', '-g', '--git', '-h', '--mercurial', '-l',
                   '--logger', '-m', '--manual', '-c', '--complete']
     run_arguments = list(click.get_current_context().args)
     len_args = 0

--- a/client.py
+++ b/client.py
@@ -121,6 +121,20 @@ def cli(complete=False, git=False, mercurial=False, logger=False, manual=False,
     generated for
     :return:
     """
+    valid_args = ['-d', '--days', '-g', '--git', '-h', '--hg', '-l',
+                  '--logger', '-m', '--manual', '-c', '--complete']
+    run_arguments = list(click.get_current_context().args)
+    len_args = 0
+    list_args = []
+    for arg in run_arguments:
+        if arg not in valid_args:
+            len_args += 1
+            list_args.append(arg)
+    if len(list_args) >= 1:
+        print("The following Arguments " + str(
+            list_args) + " are not available.\n"
+                         "Please type python client.py -h for a list of"
+                         " available arguments.")
     from fic_modules.configuration import LOGGER
     if days:
         run_days(LOGGER, days)


### PR DESCRIPTION
This PR handles solves the problem of unknown arguments.
However, this needs manual intervention in `valid_args` whenever we implement a new argument.
Had a look if this can be translated into a `try except` but it seems like `click` doesn't let us handle such exceptions.
