### PR TITLE
Issue 219: Fix the Mercurial logic to show commits in the markdown table from the newest to oldest

### DIFF
--- a/fic_modules/hg.py
+++ b/fic_modules/hg.py
@@ -249,7 +249,7 @@ def extract_json_from_hg(json_files, path_to_files, days_to_generate):
                                          repository_json)
                 if "0" in data:
                     del data["0"]
-                for changeset_iterator in data:
+                for changeset_iterator in sorted(data, reverse=True):
                     for commit_iterator in data\
                             .get(changeset_iterator)\
                             .get("changeset_commits"):

--- a/fic_modules/markdown_modules.py
+++ b/fic_modules/markdown_modules.py
@@ -218,6 +218,7 @@ def create_hg_md_table(repository_name):
 
         for key in data:
             if key > "0":
+                key = str(len(data) - int(key))
                 changeset_id = data.get(key).get("changeset_number")
                 date_of_push = data.get(key).get("date_of_push")
                 try:


### PR DESCRIPTION
This PR will close Issue #219 

Changed the logic to iterate trough the Json data starting from the end of the dict. (from the newest commit to the oldest commit). 
This PR will fix the order of the HG commits in all MD files:
 - [changelog.md](https://github.com/mozilla-releng/firefox-infra-changelog/blob/master/changelog.md)
 - [hg_files/[repo_name].md](https://github.com/mozilla-releng/firefox-infra-changelog/tree/master/hg_files)