### PR TITLE
Issue 166: Generate and add Bugzilla links to the bug numbers in markdown files.

### DIFF
--- a/fic_modules/helper_functions.py
+++ b/fic_modules/helper_functions.py
@@ -225,3 +225,34 @@ def get_keys(name):
         REPO_LIST.append(key)
     return REPO_LIST
 
+
+def replace_bug_with_url(message, LOGGER):
+    commit_text = message.split()
+    try:
+        position_bug = re.search("Bug", message, re.IGNORECASE).regs[0]
+    except AttributeError:
+        position_bug = False
+
+
+    if position_bug:
+        control_number = len(position_bug)
+        for bug in position_bug:
+            LOGGER.info("%s Bug links left to generate.", control_number)
+            control_number -= 1
+            integer_position = bug + 1
+            result = commit_text[integer_position]
+            generated_link = "https://bugzilla.mozilla.org/show_bug.cgi?id=" +\
+                             str(result)
+            for entry in position_bug:
+                replace = re.sub(str("Bug {}".format(result)), str(generated_link),
+                                 message)
+                replace2 = re.sub(str(generated_link), "[Bug {}]({})".format(result, generated_link), replace)
+                message = replace2
+
+    position_bug = None
+    commit_text = None
+    control_number = None
+    integer_position = None
+    result = None
+    replace = None
+    return message

--- a/fic_modules/helper_functions.py
+++ b/fic_modules/helper_functions.py
@@ -237,7 +237,8 @@ def replace_bug_with_url(message, LOGGER):
     if position_bug:
         control_number = len(position_bug)
         for bug in position_bug:
-            LOGGER.info("%s Bug links left to generate.", control_number)
+            if len(position_bug) > 9:
+                LOGGER.info("%s Bug links left to generate.", control_number)
             control_number -= 1
             integer_position = bug + 1
             result = commit_text[integer_position]

--- a/fic_modules/helper_functions.py
+++ b/fic_modules/helper_functions.py
@@ -227,33 +227,27 @@ def get_keys(name):
 
 
 def replace_bug_with_url(message, LOGGER):
+    """
+    This function generate and replace bug numbers with bugzilla links in commit messages.
+    Supports MD format.
+    :param message: commit message
+    :param LOGGER: used for displaying the logger while running the script
+    manually from terminal
+    :return: the commit message with the bug link
+    """
     commit_text = message.split()
-    try:
-        position_bug = re.search("Bug", message, re.IGNORECASE).regs[0]
-    except AttributeError:
-        position_bug = False
+    for element in range(len(commit_text)):
+        if commit_text[element].lower() == "bug" and element < len(commit_text) - 1:
+            bug_number = re.sub("[(:,.;)]", "", commit_text[element + 1])
+            try:
+                bug_number = int(bug_number)
+                generated_link = "https://bugzilla.mozilla.org/show_bug.cgi?id=" + \
+                                 str(bug_number)
+                LOGGER.info("Link generated for Bug {} - {}".format(bug_number, generated_link))
+                commit_text[element] = '[' + 'Bug' + ' ' + str(bug_number)
+                commit_text[element + 1] = '](' + generated_link + ')'
+            except ValueError:
+                LOGGER.info("Invalid bug number: > {} < in message: {}".format(commit_text[element + 1], message))
+    commit_text = ' '.join(commit_text)
+    return commit_text
 
-
-    if position_bug:
-        control_number = len(position_bug)
-        for bug in position_bug:
-            if len(position_bug) > 9:
-                LOGGER.info("%s Bug links left to generate.", control_number)
-            control_number -= 1
-            integer_position = bug + 1
-            result = commit_text[integer_position]
-            generated_link = "https://bugzilla.mozilla.org/show_bug.cgi?id=" +\
-                             str(result)
-            for entry in position_bug:
-                replace = re.sub(str("Bug {}".format(result)), str(generated_link),
-                                 message)
-                replace2 = re.sub(str(generated_link), "[Bug {}]({})".format(result, generated_link), replace)
-                message = replace2
-
-    position_bug = None
-    commit_text = None
-    control_number = None
-    integer_position = None
-    result = None
-    replace = None
-    return message

--- a/fic_modules/hg.py
+++ b/fic_modules/hg.py
@@ -18,7 +18,8 @@ from fic_modules.configuration import (
 from fic_modules.helper_functions import (
     remove_chars,
     compare_files,
-    extract_reviewer
+    extract_reviewer,
+    replace_bug_with_url
 )
 
 
@@ -266,6 +267,8 @@ def extract_json_from_hg(json_files, path_to_files, days_to_generate):
                                 .get("commit_message")
                             commit_description = \
                                 remove_chars(commit_description, "\n")
+                            commit_description = \
+                                replace_bug_with_url(commit_description, LOGGER)
                             commit_url = data.get(changeset_iterator) \
                                 .get("changeset_commits") \
                                 .get(commit_iterator) \

--- a/fic_modules/markdown_modules.py
+++ b/fic_modules/markdown_modules.py
@@ -11,7 +11,8 @@ from os.path import (
 from datetime import datetime
 from fic_modules.helper_functions import (
     filter_strings,
-    remove_chars
+    remove_chars,
+    replace_bug_with_url
 )
 from fic_modules.configuration import (
     LAST_WEEK,
@@ -81,6 +82,7 @@ def create_git_md_table(repository_name, path_to_files):
 
                 commit_author = filter_strings(commit_author)
                 message = filter_strings(message)
+                message = replace_bug_with_url(message, LOGGER)
 
                 row = "|" + commit_number + \
                       "|" + commit_author + \
@@ -239,6 +241,7 @@ def create_hg_md_table(repository_name):
                             message = re.sub("\n|", "", message)
 
                             message = filter_strings(message)
+                            message = replace_bug_with_url(message, LOGGER)
                             url = data\
                                 .get(key)\
                                 .get("changeset_commits")\


### PR DESCRIPTION
This PR will close Issue #166 

The function added in this PR will return the commit message with all bug numbers replaced with bugzilla links. 
With this PR the functions that generate the MD tables will use this new function to add the links in the commit messages. 

e.g [Bug 1529210 ](https://bugzilla.mozilla.org/show_bug.cgi?id=1529210) Add new Raptor tests in tp6m-5 r=davehunt