### PR TITLE
Changelog.json is no longer re-written repeatedly

### DIFF
--- a/client.py
+++ b/client.py
@@ -6,6 +6,7 @@ could affect Firefox CI Infra
 import logging
 from datetime import datetime
 import click
+import json
 from fic_modules.git import create_files_for_git
 from fic_modules.hg import create_files_for_hg
 from fic_modules.helper_functions import (
@@ -22,8 +23,12 @@ from fic_modules.markdown_modules import generate_main_md_table
 def run_all(logger, days):
     logger.info("======== Logging in ALL mode on %s ========", datetime
                 .now())
-    create_files_for_git(REPOSITORIES, onerepo=False)
-    create_files_for_hg(REPOSITORIES, onerepo=False)
+    git_data = create_files_for_git(REPOSITORIES, onerepo=False)
+    hg_data = create_files_for_hg(REPOSITORIES, onerepo=False)
+    data_file = open("changelog.json", "w")
+    json.dump(git_data, data_file, indent=2)
+    json.dump(hg_data, data_file, indent=2)
+    data_file.close()
     clear_file("changelog.md", int(days))
     generate_main_md_table("hg_files", int(days))
     generate_main_md_table("git_files", int(days))
@@ -32,7 +37,10 @@ def run_all(logger, days):
 def run_git(logger, days):
     logger.info("======== Logging in GIT mode on %s ========", datetime
                 .now())
-    create_files_for_git(REPOSITORIES, onerepo=False)
+    git_data = create_files_for_git(REPOSITORIES, onerepo=False)
+    data_file = open("changelog.json", "w")
+    json.dump(git_data, data_file, indent=2)
+    data_file.close()
     clear_file("changelog.md", int(days))
     generate_main_md_table("hg_files", int(days))
     generate_main_md_table("git_files", int(days))
@@ -42,7 +50,10 @@ def run_git(logger, days):
 def run_hg(logger, days):
     logger.info("======== Logging in HG mode on %s ========", datetime
                 .now())
-    create_files_for_hg(REPOSITORIES, onerepo=False)
+    hg_data = create_files_for_hg(REPOSITORIES, onerepo=False)
+    data_file = open("changelog.json", "w")
+    json.dump(hg_data, data_file, indent=2)
+    data_file.close()
     clear_file("changelog.md", int(days))
     generate_main_md_table("hg_files", int(days))
     generate_main_md_table("git_files", int(days))

--- a/fic_modules/helper_functions.py
+++ b/fic_modules/helper_functions.py
@@ -3,6 +3,7 @@ This module contains functions that are for other scopes which aim to get
 better functionality out of the code and not directly related to the script.
 """
 import re
+import json
 from github import GithubException
 from fic_modules.configuration import (
     REPOSITORIES,
@@ -251,3 +252,20 @@ def replace_bug_with_url(message, LOGGER):
     commit_text = ' '.join(commit_text)
     return commit_text
 
+
+def populate_changelog_json(work_dir, repo_name):
+    """
+    Takes the data from within json files and prepares it for changelog.json
+    :param work_dir:
+    :param repo_name:
+    :return: returns all the data from a single json file
+    """
+    json_file = open(work_dir + repo_name + ".json", "r")
+    content = json.load(json_file)
+    try:
+        del content["0"]
+    except KeyError:
+        pass
+    data = {}
+    data.update({repo_name: content})
+    return data

--- a/fic_modules/hg.py
+++ b/fic_modules/hg.py
@@ -19,7 +19,8 @@ from fic_modules.helper_functions import (
     remove_chars,
     compare_files,
     extract_reviewer,
-    replace_bug_with_url
+    replace_bug_with_url,
+    populate_changelog_json
 )
 
 
@@ -78,6 +79,7 @@ def create_files_for_hg(repositories_holder, onerepo):
     """
     from fic_modules.markdown_modules import create_hg_md_table
     if onerepo:
+        complete_data = {}
         repository_url = REPOSITORIES\
             .get("Mercurial")\
             .get(repositories_holder)\
@@ -90,8 +92,12 @@ def create_files_for_hg(repositories_holder, onerepo):
         filter_hg_commit_data(repositories_holder,
                               folders_to_check,
                               repository_url)
+        work_path = WORKING_DIR + "/hg_files/"
+        repo_data = populate_changelog_json(work_path, repositories_holder)
+        complete_data.update(repo_data)
         create_hg_md_table(repositories_holder)
     else:
+        complete_data = {}
         for repo in repositories_holder["Mercurial"]:
             repository_name = repo
             repository_url = repositories_holder\
@@ -104,7 +110,11 @@ def create_files_for_hg(repositories_holder, onerepo):
             filter_hg_commit_data(repository_name,
                                   folders_to_check,
                                   repository_url)
+            work_path = WORKING_DIR + "/hg_files/"
+            repo_data = populate_changelog_json(work_path, repository_name)
+            complete_data.update(repo_data)
             create_hg_md_table(repository_name)
+    return complete_data
 
 
 def filter_hg_commit_data(repository_name, folders_to_check, repository_url):
@@ -197,15 +207,6 @@ def json_writer_hg(repository_name, new_commits):
         json_file = open(WORKING_DIR + "/hg_files/" + hg_json_filename, "w")
         json.dump(json_content, json_file, indent=2)
         json_file.close()
-        try:
-            del json_content["0"]
-        except KeyError:
-            pass
-        with open("changelog.json", "r") as file:
-            data = json.load(file)
-        data[repository_name] = json_content
-        with open("changelog.json", "w") as file:
-            json.dump(data, file, indent=2)
 
 
 def extract_json_from_hg(json_files, path_to_files, days_to_generate):


### PR DESCRIPTION
With these changes the main json, containing all the data from both hg and git files, will only be written once.
This fixed issue #222 

- create_ files_for_git andcreate_ files_for_hg functions now return a dictionary called "complete_data"
- in the variable "complete_data" we store all the git or hg data that needs to be written to changelog.json
