### PR TITLE
[Issue 262] Implement Logger Level based on Environment variable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The tool uses py-github and github token and requests on all mozilla's Git/HG in
 1. After you clone the repository, please run `pip3 install -r requirements.txt`
 2. Generate a Github [Personal access token](https://github.com/settings/tokens) and add an environment variable called `GIT_TOKEN` containing the generated token.
 3. Run the script with `python3 client.py <optional-flags>`
-4. **OPTIONAL**: You can add an optional environment variable called `LoggerLevel` to change the information which gets logged. Example: `LoggerLevel=logging.WARNING`. This will give you extra information such as: [e7c515](https://github.com/mozilla-releng/firefox-infra-changelog/pull/263/commits/e7c515cd1249c60921a22cb2876deef44b5fe7a4#diff-55a742f2aefb0ba0012723d8409292b3R249)
+4. **OPTIONAL**: You can add an optional environment variable called `LoggerLevel` to change the information which gets logged. Example: `LoggerLevel=WARNING`. This will give you extra information such as: [e7c515](https://github.com/mozilla-releng/firefox-infra-changelog/pull/263/commits/e7c515cd1249c60921a22cb2876deef44b5fe7a4#diff-55a742f2aefb0ba0012723d8409292b3R249)
 
 # Flags
 | Short Flag | Long Flag | Description |

--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ The tool uses py-github and github token and requests on all mozilla's Git/HG in
 
 # Install process:
 1. After you clone the repository, please run `pip3 install -r requirements.txt`
-2. Generate a Github [Personal access token](https://github.com/settings/tokens) and add an environment variable called `GIT_TOKEN`containing the generated token.
+2. Generate a Github [Personal access token](https://github.com/settings/tokens) and add an environment variable called `GIT_TOKEN` containing the generated token.
 3. Run the script with `python3 client.py <optional-flags>`
+4. **OPTIONAL**: You can add an optional environment variable called `LoggerLevel` to change the information which gets logged. Example: `LoggerLevel=logger.WARNING`. This will give you extra information such as: [e7c515](https://github.com/mozilla-releng/firefox-infra-changelog/pull/263/commits/e7c515cd1249c60921a22cb2876deef44b5fe7a4#diff-55a742f2aefb0ba0012723d8409292b3R249)
 
 # Flags
 | Short Flag | Long Flag | Description |

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The tool uses py-github and github token and requests on all mozilla's Git/HG in
 1. After you clone the repository, please run `pip3 install -r requirements.txt`
 2. Generate a Github [Personal access token](https://github.com/settings/tokens) and add an environment variable called `GIT_TOKEN` containing the generated token.
 3. Run the script with `python3 client.py <optional-flags>`
-4. **OPTIONAL**: You can add an optional environment variable called `LoggerLevel` to change the information which gets logged. Example: `LoggerLevel=logger.WARNING`. This will give you extra information such as: [e7c515](https://github.com/mozilla-releng/firefox-infra-changelog/pull/263/commits/e7c515cd1249c60921a22cb2876deef44b5fe7a4#diff-55a742f2aefb0ba0012723d8409292b3R249)
+4. **OPTIONAL**: You can add an optional environment variable called `LoggerLevel` to change the information which gets logged. Example: `LoggerLevel=logging.WARNING`. This will give you extra information such as: [e7c515](https://github.com/mozilla-releng/firefox-infra-changelog/pull/263/commits/e7c515cd1249c60921a22cb2876deef44b5fe7a4#diff-55a742f2aefb0ba0012723d8409292b3R249)
 
 # Flags
 | Short Flag | Long Flag | Description |

--- a/fic_modules/configuration.py
+++ b/fic_modules/configuration.py
@@ -23,7 +23,7 @@ LAST_MONTH = datetime.utcnow() - timedelta(days=31)
 CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
 WORKING_DIR = CURRENT_DIR.strip("/fic_modules")
 
-logging.basicConfig(level=logging.INFO,
+logging.basicConfig(level=os.environ.get("LoggerLevel", logging.INFO),
                     format="[%(asctime)s] %(levelname)s [%(name)s.%(funcName)\
                     s:%(lineno)d] %(message)s",
                     datefmt="%H:%M:%S",

--- a/fic_modules/helper_functions.py
+++ b/fic_modules/helper_functions.py
@@ -246,7 +246,8 @@ def replace_bug_with_url(message, LOGGER):
                 commit_text[element] = '[' + 'Bug' + ' ' + str(bug_number)
                 commit_text[element + 1] = '](' + generated_link + ')'
             except ValueError:
-                pass
+                LOGGER.warning("Invalid bug number: > {} < in message: {}"
+                               .format(commit_text[element + 1], message))
     commit_text = ' '.join(commit_text)
     return commit_text
 

--- a/fic_modules/helper_functions.py
+++ b/fic_modules/helper_functions.py
@@ -246,8 +246,9 @@ def replace_bug_with_url(message, LOGGER):
                 commit_text[element] = '[' + 'Bug' + ' ' + str(bug_number)
                 commit_text[element + 1] = '](' + generated_link + ')'
             except ValueError:
-                LOGGER.warning("Invalid bug number: > {} < in message: {}"
-                               .format(commit_text[element + 1], message))
+                if LOGGER.root.level == 30:
+                    LOGGER.warning("Invalid bug number: > {} < in message: {}"
+                                 .format(commit_text[element + 1], message))
     commit_text = ' '.join(commit_text)
     return commit_text
 


### PR DESCRIPTION
PR will fix issue #262 

## The PR will implement:
- OS Environment Variable, called `LoggerLevel`. If variable not offered, fallback to default `logger.INFO`.
- Will print **Invalid Bug number** logs if configuration is set to `logging.WARNING`
- Update `README.md` to include the new logging abilities.

## Left to do:
- [x] os.environ.get() will return a string, we need to find out how to send an object.
- [x] Don't write **Invalid Bug number** to file if level is logging.INFO
