### PR TITLE
Issue 219: Fix the Mercurial logic to show commits in the markdown table from the newest to oldest

### DIFF
--- a/fic_modules/hg.py
+++ b/fic_modules/hg.py
@@ -239,7 +239,7 @@ def extract_json_from_hg(repo_name, days_to_generate):
                                          repository_url,
                                          repository_json)
                 count_pushes = 0
-                for changeset_iterator in data.get("Hg").get(repo_name):
+                for changeset_iterator in sorted(data.get("Hg").get(repo_name), reverse=True):
                     for commit_iterator in data.get("Hg").get(repo_name) \
                             .get(changeset_iterator)\
                             .get("changeset_commits"):


### PR DESCRIPTION
This PR is a fix for Issue #219 

Changed the logic to iterate trough the Json data starting from the end of the dict. (from the newest commit to the oldest commit). 
This PR will fix the order of the HG commits in the main md table.