### PR TITLE
Issue 319 - Saving only the version bumping commit

### DIFF
--- a/fic_modules/git.py
+++ b/fic_modules/git.py
@@ -56,8 +56,6 @@ def filter_git_commit_data(repository_name, repository_team, repository_type,
     if repository_type == "commit-keyword":
         filter_git_commit_keyword(repository_name, repository_path)
     # TYPE = TAG
-    if repository_type == "script":
-        filter_git_tag(repository_name, repository_team, repository_path)
     if repository_type == "tag":
         if repository_name == "build-puppet":
             filter_git_tag_bp(repository_name,

--- a/fic_modules/git.py
+++ b/fic_modules/git.py
@@ -56,6 +56,8 @@ def filter_git_commit_data(repository_name, repository_team, repository_type,
     if repository_type == "commit-keyword":
         filter_git_commit_keyword(repository_name, repository_path)
     # TYPE = TAG
+    if repository_type == "script":
+        filter_git_scriptworkers(repository_team, repository_name)
     if repository_type == "tag":
         if repository_name == "build-puppet":
             filter_git_tag_bp(repository_name,
@@ -194,39 +196,50 @@ def filter_git_tag_bp(repository_name, repository_path):
     json_writer_git(repository_name, new_commit_dict)
 
 
-def filter_git_scriptworkers(latest_releases, repo_team, script_repo):
+def filter_git_scriptworkers(repo_team, script_repo):
     """
     Filters the scriptworker repos that are under build-puppet
-    :param latest_releases: data about last release
     :param repo_team: team name as a string
     :param script_repo: scriptworker repo we are working on
     :return: returns the new commits of a repo
     """
     last_local_date = get_date_from_json(script_repo)
-    new_commit_version_date = \
-        datetime.strptime(latest_releases
-                          .get("latest_release")
-                          .get("date"),
-                          "%Y-%m-%d %H:%M:%S")
-    commit_number = 0
-    new_scriptworker_dict = {
-        (int(commit_number)): {"lastChecked": str(datetime.utcnow()),
-                               "last_releases": latest_releases}}
-    new_repo_path = repo_team + script_repo
-    for commit2 in GIT.get_repo(new_repo_path).get_commits(
-            since=last_local_date):
-        last_modified = \
-            datetime.strftime(parse(commit2.last_modified),
+    latest_releases = get_version(script_repo, repo_team)
+    with open("./repositories.json", "r") as file:
+        json_content = json.load(file)
+        version_path = json_content.get("Github").get(script_repo) \
+            .get("configuration").get("version-path")
+    checker = compare_versions(version_path, script_repo, latest_releases)
+    if checker:
+        new_commit_version_date = \
+            datetime.strptime(latest_releases
+                              .get("latest_release")
+                              .get("date"),
                               "%Y-%m-%d %H:%M:%S")
-        last_modified = datetime.strptime(last_modified,
-                                          "%Y-%m-%d %H:%M:%S")
-        if last_modified <= new_commit_version_date:
-            each_commit2 = {}
-            commit_number += 1
-            commit_details = get_commit_details(commit2)
-            each_commit2.update({int(commit_number): commit_details})
-            new_scriptworker_dict.update(each_commit2)
-    return new_scriptworker_dict
+        commit_number = 0
+        new_scriptworker_dict = {
+            (int(commit_number)): {"lastChecked": str(datetime.utcnow()),
+                                   "last_releases": latest_releases}}
+        new_repo_path = repo_team + script_repo
+        for commit2 in GIT.get_repo(new_repo_path).get_commits(
+                since=last_local_date):
+            last_modified = \
+                datetime.strftime(parse(commit2.last_modified),
+                                  "%Y-%m-%d %H:%M:%S")
+            last_modified = datetime.strptime(last_modified,
+                                              "%Y-%m-%d %H:%M:%S")
+            if last_modified <= new_commit_version_date:
+                each_commit2 = {}
+                commit_number += 1
+                commit_details = get_commit_details(commit2)
+                # if commit contain tag
+                    each_commit2.update({int(commit_number): commit_details})
+                    new_scriptworker_dict.update(each_commit2)
+                # else:
+                #   pass
+        json_writer_git(script_repo, new_scriptworker_dict)
+    else:
+        LOGGER.info("No new changes entered production")
 
 
 def filter_git_tag(repository_name, repository_team, repository_path):

--- a/fic_modules/git.py
+++ b/fic_modules/git.py
@@ -196,52 +196,6 @@ def filter_git_tag_bp(repository_name, repository_path):
     json_writer_git(repository_name, new_commit_dict)
 
 
-# def filter_git_scriptworkers(repo_team, script_repo):
-#     """
-#     Filters the scriptworker repos that are under build-puppet
-#     :param repo_team: team name as a string
-#     :param script_repo: scriptworker repo we are working on
-#     :return: returns the new commits of a repo
-#     """
-#     last_local_date = get_date_from_json(script_repo)
-#     latest_releases = get_version(script_repo, repo_team)
-#     with open("./repositories.json", "r") as file:
-#         json_content = json.load(file)
-#         version_path = json_content.get("Github").get(script_repo) \
-#             .get("configuration").get("version-path")
-#     checker = compare_versions(version_path, script_repo, latest_releases)
-#     if checker:
-#         new_commit_version_date = \
-#             datetime.strptime(latest_releases
-#                               .get("latest_release")
-#                               .get("date"),
-#                               "%Y-%m-%d %H:%M:%S")
-#         commit_number = 0
-#         new_scriptworker_dict = {
-#             (int(commit_number)): {"lastChecked": str(datetime.utcnow()),
-#                                    "last_releases": latest_releases}}
-#         new_repo_path = repo_team + script_repo
-#         for commit2 in GIT.get_repo(new_repo_path).get_commits(
-#                 since=last_local_date):
-#             last_modified = \
-#                 datetime.strftime(parse(commit2.last_modified),
-#                                   "%Y-%m-%d %H:%M:%S")
-#             last_modified = datetime.strptime(last_modified,
-#                                               "%Y-%m-%d %H:%M:%S")
-#             if last_modified <= new_commit_version_date:
-#                 each_commit2 = {}
-#                 commit_number += 1
-#                 commit_details = get_commit_details(commit2)
-#                 # if commit contain tag
-#                     each_commit2.update({int(commit_number): commit_details})
-#                     new_scriptworker_dict.update(each_commit2)
-#                 # else:
-#                 #   pass
-#         json_writer_git(script_repo, new_scriptworker_dict)
-#     else:
-#         LOGGER.info("No new changes entered production")
-
-
 def filter_git_tag(repository_name, repository_team, repository_path):
     """
     Filters out only the data that we need from a commit
@@ -265,25 +219,17 @@ def filter_git_tag(repository_name, repository_team, repository_path):
     checker = compare_versions(version_path, repository_name, latest_releases)
     if checker:
         last_commit_date = get_date_from_json(repository_name)
-        new_version_commit_date = datetime.strptime(latest_releases
-                                                    .get("latest_release")
-                                                    .get("date"),
-                                                    "%Y-%m-%d %H:%M:%S")
         new_commit_dict = {"0": {"lastChecked": str(datetime.utcnow()),
                                  "last_releases": latest_releases}}
         for commit in GIT.get_repo(repository_path) \
                 .get_commits(since=last_commit_date):
-            last_modified = datetime.strftime(parse(commit.last_modified),
-                                              "%Y-%m-%d %H:%M:%S")
-            last_modified = datetime.strptime(last_modified,
-                                              "%Y-%m-%d %H:%M:%S")
-            if last_modified == new_version_commit_date:
+            commit_message = commit.commit.message
+            bump_version = latest_releases.get("latest_release").get("version")
+            if commit_message == bump_version:
                 each_commit = {}
                 number += 1
                 each_commit.update({int(number): get_commit_details(commit)})
                 new_commit_dict.update(each_commit)
-        if number == 0:
-            LOGGER.info("Version-bumping commit isn't tagged")
 
         json_writer_git(repository_name, new_commit_dict)
     else:

--- a/repositories.json
+++ b/repositories.json
@@ -90,7 +90,7 @@
       "top-contributors": [" ", " "],
       "order": 11,
       "configuration": {
-        "type": "tag",
+        "type": "script",
         "folders-to-check": [],
         "version-path": "https://raw.githubusercontent.com/mozilla-releng/build-puppet/master/modules/beetmover_scriptworker/files/requirements.txt"
       }
@@ -102,7 +102,7 @@
       "top-contributors": [" ", " "],
       "order": 9,
       "configuration": {
-        "type": "tag",
+        "type": "script",
         "folders-to-check": [],
         "version-path": "https://raw.githubusercontent.com/mozilla-releng/build-puppet/master/modules/addon_scriptworker/files/requirements.txt"
       }
@@ -114,7 +114,7 @@
       "top-contributors": [" ", " "],
       "order": 16,
       "configuration": {
-        "type": "tag",
+        "type": "script",
         "folders-to-check": [],
         "version-path": "https://raw.githubusercontent.com/mozilla-releng/build-puppet/master/modules/shipit_scriptworker/files/requirements.txt"
       }
@@ -126,7 +126,7 @@
       "top-contributors": [" ", " "],
       "order": 12,
       "configuration": {
-        "type": "tag",
+        "type": "script",
         "folders-to-check": [],
         "version-path": "https://raw.githubusercontent.com/mozilla-releng/build-puppet/master/modules/bouncer_scriptworker/files/requirements.txt"
       }
@@ -138,7 +138,7 @@
       "top-contributors": [" ", " "],
       "order": 19,
       "configuration": {
-        "type": "tag",
+        "type": "script",
         "folders-to-check": [],
         "version-path": "https://raw.githubusercontent.com/mozilla-releng/build-puppet/master/modules/tree_scriptworker/files/requirements.txt"
       }
@@ -150,7 +150,7 @@
       "top-contributors": [" ", " "],
       "order": 15,
       "configuration": {
-        "type": "tag",
+        "type": "script",
         "folders-to-check": [],
         "version-path": "https://raw.githubusercontent.com/mozilla-releng/build-puppet/master/modules/signing_scriptworker/files/requirements.txt"
       }
@@ -162,7 +162,7 @@
       "top-contributors": [" ", " "],
       "order": 14,
       "configuration": {
-        "type": "tag",
+        "type": "script",
         "folders-to-check": [],
         "version-path": "https://raw.githubusercontent.com/mozilla-releng/build-puppet/master/modules/pushsnap_scriptworker/files/requirements.txt"
       }
@@ -174,7 +174,7 @@
       "top-contributors": [" ", " "],
       "order": 17,
       "configuration": {
-        "type": "tag",
+        "type": "script",
         "folders-to-check": [],
         "version-path": "https://raw.githubusercontent.com/mozilla-releng/build-puppet/master/modules/signing_scriptworker/files/requirements.txt"
       }
@@ -186,7 +186,7 @@
       "top-contributors": [" ", " "],
       "order": 13,
       "configuration": {
-        "type": "tag",
+        "type": "script",
         "folders-to-check": [],
         "version-path": "https://raw.githubusercontent.com/mozilla-releng/build-puppet/master/modules/pushapk_scriptworker/files/requirements.txt"
       }
@@ -198,7 +198,7 @@
       "top-contributors": [" ", " "],
       "order": 10,
       "configuration": {
-        "type": "tag",
+        "type": "script",
         "folders-to-check": [],
         "version-path": "https://raw.githubusercontent.com/mozilla-releng/build-puppet/master/modules/balrog_scriptworker/files/requirements.txt"
       }

--- a/repositories.json
+++ b/repositories.json
@@ -90,7 +90,7 @@
       "top-contributors": [" ", " "],
       "order": 11,
       "configuration": {
-        "type": "script",
+        "type": "tag",
         "folders-to-check": [],
         "version-path": "https://raw.githubusercontent.com/mozilla-releng/build-puppet/master/modules/beetmover_scriptworker/files/requirements.txt"
       }
@@ -102,7 +102,7 @@
       "top-contributors": [" ", " "],
       "order": 9,
       "configuration": {
-        "type": "script",
+        "type": "tag",
         "folders-to-check": [],
         "version-path": "https://raw.githubusercontent.com/mozilla-releng/build-puppet/master/modules/addon_scriptworker/files/requirements.txt"
       }
@@ -114,7 +114,7 @@
       "top-contributors": [" ", " "],
       "order": 16,
       "configuration": {
-        "type": "script",
+        "type": "tag",
         "folders-to-check": [],
         "version-path": "https://raw.githubusercontent.com/mozilla-releng/build-puppet/master/modules/shipit_scriptworker/files/requirements.txt"
       }
@@ -126,7 +126,7 @@
       "top-contributors": [" ", " "],
       "order": 12,
       "configuration": {
-        "type": "script",
+        "type": "tag",
         "folders-to-check": [],
         "version-path": "https://raw.githubusercontent.com/mozilla-releng/build-puppet/master/modules/bouncer_scriptworker/files/requirements.txt"
       }
@@ -138,7 +138,7 @@
       "top-contributors": [" ", " "],
       "order": 19,
       "configuration": {
-        "type": "script",
+        "type": "tag",
         "folders-to-check": [],
         "version-path": "https://raw.githubusercontent.com/mozilla-releng/build-puppet/master/modules/tree_scriptworker/files/requirements.txt"
       }
@@ -150,7 +150,7 @@
       "top-contributors": [" ", " "],
       "order": 15,
       "configuration": {
-        "type": "script",
+        "type": "tag",
         "folders-to-check": [],
         "version-path": "https://raw.githubusercontent.com/mozilla-releng/build-puppet/master/modules/signing_scriptworker/files/requirements.txt"
       }
@@ -162,7 +162,7 @@
       "top-contributors": [" ", " "],
       "order": 14,
       "configuration": {
-        "type": "script",
+        "type": "tag",
         "folders-to-check": [],
         "version-path": "https://raw.githubusercontent.com/mozilla-releng/build-puppet/master/modules/pushsnap_scriptworker/files/requirements.txt"
       }
@@ -174,7 +174,7 @@
       "top-contributors": [" ", " "],
       "order": 17,
       "configuration": {
-        "type": "script",
+        "type": "tag",
         "folders-to-check": [],
         "version-path": "https://raw.githubusercontent.com/mozilla-releng/build-puppet/master/modules/signing_scriptworker/files/requirements.txt"
       }
@@ -186,7 +186,7 @@
       "top-contributors": [" ", " "],
       "order": 13,
       "configuration": {
-        "type": "script",
+        "type": "tag",
         "folders-to-check": [],
         "version-path": "https://raw.githubusercontent.com/mozilla-releng/build-puppet/master/modules/pushapk_scriptworker/files/requirements.txt"
       }
@@ -198,7 +198,7 @@
       "top-contributors": [" ", " "],
       "order": 10,
       "configuration": {
-        "type": "script",
+        "type": "tag",
         "folders-to-check": [],
         "version-path": "https://raw.githubusercontent.com/mozilla-releng/build-puppet/master/modules/balrog_scriptworker/files/requirements.txt"
       }


### PR DESCRIPTION
This PR fixes and closes issue #319 : 
- deleted _**filter_git_scriptworkers()**_ as it wasn't used/required anymore
- deleted **new_version_commit_date** and **last_modified variables** since we are no longer using the date & time to determine whether we should save a commit, but rather the commit message 