### PR TITLE
Issue 406 - replace the old arguments from client.py and update-files.py

### DIFF
--- a/client.py
+++ b/client.py
@@ -182,18 +182,18 @@ def cli(all=False, git=False, mercurial=False, logger=False, repo=False,
         days=False, push=False):
     """
     Main function of the script that handles how the script runs
-    :param update: push the new changes to Github
-    :param complete: Used to run the script for all of the repositories.
+    :param push: push the new changes to Github
+    :param all: Used to run the script for all of the repositories.
     :param git: Used to run the script in git mode only
     :param mercurial: Used to run the script in mercurial mode only
     :param logger: used for displaying the logger while running the script
     manually from terminal.
-    :param manual: Used for running the script for specific repositories.
+    :param repo: Used for running the script for specific repositories.
     :param days: Used to change the amount of days the changelog will be
     generated for
     """
-    valid_args = ['-d', '--days', '-g', '--git', '-h', '--mercurial', '-l',
-                  '--logger', '-m', '--manual', '-c', '--complete', '-u', '--update']
+    valid_args = ['-d', '--days', '-g', '--git', '-hg', '--mercurial', '-l',
+                  '--logger', '-r', '--repo', '-a', '--all', '-p', '--push']
     run_arguments = list(click.get_current_context().args)
     len_args = 0
     list_args = []

--- a/update-files.py
+++ b/update-files.py
@@ -10,7 +10,7 @@ files = ["git_files", "hg_files", "changelog.json", "changelog.md"]
 update_fic_files = FICGithub(files, commit_message, LOGGER, config)
 
 update_fic_files.git_pull()
-subprocess.call(['python', 'client.py', '-c', '-l'])
+subprocess.call(['python', 'client.py', '-a', '-l'])
 update_fic_files.git_add()
 update_fic_files.git_commit()
 update_fic_files.git_push()


### PR DESCRIPTION
- replace the old arguments from client.py documentation block and from valid_args[]
- change the argument in update-files.py:  -a (--all) instead of -c (--complete)

Issue #406 