### PR TITLE
Issue #438 - [ OOP ] rewrite the logic that manage the commits from github repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,4 @@
 - 9: No git authentication tokens found
 - 10: Keyboard interrupt
 - 11: Provided input is not an integer. Used in modules.FIC_MainMenu.repo_selection_menu()
+- 12: Not a git or hg repository

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 - 10: Keyboard interrupt
 - 11: Provided input is not an integer. Used in modules.FIC_MainMenu.repo_selection_menu()
 - 12: Not a git or hg repository
+- 13: Unknown GitHub response code. Used in modules.FIC_MainMenu.handle_git_exception()
 - 301: Moved Permanently
 - 302: Found
 - 304: Not Modified

--- a/modules/FIC_DataVault.py
+++ b/modules/FIC_DataVault.py
@@ -34,3 +34,6 @@ class FICDataVault:
         self.release_date = None
         self.list_of_commits = {}
         self.local_version = None
+        self.bump_version = "version 2"
+        self.keyword = None
+        self.folders_to_check = []

--- a/modules/FIC_DataVault.py
+++ b/modules/FIC_DataVault.py
@@ -33,5 +33,4 @@ class FICDataVault:
         # GIT Specific values
         self.release_date = None
         self.list_of_commits = {}
-
-
+        self.local_version = None

--- a/modules/FIC_DataVault.py
+++ b/modules/FIC_DataVault.py
@@ -21,7 +21,7 @@ class FICDataVault:
         self.commit_date          = None
         self.commit_files_changed = []
         self.last_check           = None
-
+        self.repo_name            = None
         # HG Specific values
         self.changeset_index  = None
         self.changeset = None
@@ -29,6 +29,7 @@ class FICDataVault:
         self.hg_commits_list = None
         self.changesets_json = None
         self.constructed_dict = {}
+        self.last_local_push_id = None
 
         # GIT Specific values
         self.release_date = None
@@ -37,3 +38,4 @@ class FICDataVault:
         self.bump_version = "version 2"
         self.keyword = None
         self.folders_to_check = []
+        self.repo_type = None

--- a/modules/FIC_DataVault.py
+++ b/modules/FIC_DataVault.py
@@ -5,11 +5,13 @@
 
 class FICDataVault:
     def __init__(self):
+
         # Common Data
         self.uid = int()  # Used to find the object.
         self.repos_container = dict()
 
         # Commit Specific Data
+
         # Common Git and HG values
         self.commit_type          = None  # Can be "git" or "hg"
         self.commit_number        = None
@@ -22,6 +24,7 @@ class FICDataVault:
         self.commit_files_changed = []
         self.last_check           = None
         self.repo_name            = None
+
         # HG Specific values
         self.changeset_index  = None
         self.changeset = None
@@ -32,10 +35,11 @@ class FICDataVault:
         self.last_local_push_id = None
 
         # GIT Specific values
+        self.release_tag = None
         self.release_date = None
         self.list_of_commits = {}
         self.local_version = None
-        self.bump_version = "version 2"
+        self.bump_version = None
         self.keyword = None
         self.folders_to_check = []
         self.repo_type = None

--- a/modules/FIC_Exceptions.py
+++ b/modules/FIC_Exceptions.py
@@ -5,10 +5,9 @@ from modules.FIC_Github import FICGithub
 
 
 class FICExceptions(FICGithub):
-    def __init__(self, error):
+    def __init__(self):
         self.SIGINT = False
         FICGithub.__init__(self)
-        self.e = int(error)
 
     def signal_handler(self, signal, frame):
         self.LOGGER.info("KeyboardInterrupt (ID: {}) has been caught. Cleaning up...".format(signal))
@@ -16,7 +15,9 @@ class FICExceptions(FICGithub):
         self.revert_modified_files()
         exit(10)
 
-    def handle_git_exception(self):
+    def handle_git_exception(self, error):
+        self.e = int(error)
+
         if self.e == 301:
             self.LOGGER.critical("Error code 301: Moved Permanently")
             exit(301)
@@ -63,5 +64,8 @@ class FICExceptions(FICGithub):
 
         elif self.e == 503:
             self.LOGGER.critical("Error code 503: Service Unavailable")
-
             exit(503)
+
+        else:
+            self.LOGGER.critical("Unknown Error Code!")
+            exit(13)

--- a/modules/FIC_FileHandler.py
+++ b/modules/FIC_FileHandler.py
@@ -11,8 +11,8 @@ import os
 class FICFileHandler(FICLogger, FICDataVault):
     def __init__(self):
         FICLogger.__init__(self)
+        FICDataVault.__init__(self)
         from modules.config import CHANGELOG_JSON_PATH, CHANGELOG_MD_PATH, CHANGELOG_REPO_PATH
-
         self.changelog_json = CHANGELOG_JSON_PATH
         self.changelog_md = CHANGELOG_MD_PATH
         self.data_folder = CHANGELOG_REPO_PATH
@@ -249,8 +249,14 @@ class FICFileHandler(FICLogger, FICDataVault):
                                  "or the final location \"{}\" has not been created"
                                  .format(self.construct_path(new_path, new_file)))
 
-    def last_checked(self, repo_name):
-        return json.load(self.load(CHANGELOG_REPO_PATH, repo_name.lower() + ".json")).get("0").get("last_checked")
-
-    def local_version(self, repo_name):
-        return json.load(self.load(CHANGELOG_REPO_PATH, repo_name.lower() + ".json")).get("0").get("last_release").get("version")
+    def update_json(self, repo_name):
+        local_json_data = json.load(self.load(CHANGELOG_REPO_PATH, repo_name.lower() + ".json"))
+        try:
+            del local_json_data["0"]
+        except KeyError:
+            pass
+        for key in local_json_data.keys():
+            self.commit_number += 1
+            print(self.commit_number)
+            self.list_of_commits.update({self.commit_number: local_json_data[key]})
+        print(self.list_of_commits)

--- a/modules/FIC_FileHandler.py
+++ b/modules/FIC_FileHandler.py
@@ -250,7 +250,7 @@ class FICFileHandler(FICLogger, FICDataVault):
                                  .format(self.construct_path(new_path, new_file)))
 
     @staticmethod
-    def delete_element_0(dictionary):
+    def remove_first_element(dictionary):
         try:
             del dictionary["0"]
         except KeyError:
@@ -259,30 +259,29 @@ class FICFileHandler(FICLogger, FICDataVault):
     def last_checked(self):
         self.last_check = json.load(self.load(CHANGELOG_REPO_PATH, self.repo_name.lower() + ".json")).get("0").get("last_checked")
 
-    def handle_element_0(self):
+    def handle_first_element(self):
         if self.repo_type is None:
-            self.add_element_0_hg()
+            self.add_first_element_hg()
         elif self.repo_type is not None:
-            self.add_element_0_git()
+            self.add_first_element_git()
         else:
             exit(12)
 
-    def update_json(self, repo_name):
-        self.handle_element_0()
+    def update_json(self, repo_name, directory="data"):
+        self.handle_first_element()
         local_json_data = json.load(self.load(CHANGELOG_REPO_PATH, repo_name.lower() + ".json"))
-        self.delete_element_0(local_json_data)
+        self.remove_first_element(local_json_data)
         for key in local_json_data.keys():
             self.commit_number += 1
             self.list_of_commits.update({self.commit_number: local_json_data[key]})
-        self.save("data", "lol.json", self.list_of_commits)
+        self.save(directory, repo_name.lower() + ".json", self.list_of_commits)
 
-    def add_element_0_git(self):
+    def add_first_element_git(self):
         if self.repo_type == "tag":
             self.list_of_commits.update({"0": {"last_checked: ": self.last_check,
                                                "version: ": self.local_version}})
         else:
             self.list_of_commits.update({"0": {"last_checked: ": self.last_check}})
 
-    def add_element_0_hg(self):
+    def add_first_element_hg(self):
         self.list_of_commits.update({"0": {"last_push_id": self.last_local_push_id}})
-

--- a/modules/FIC_FileHandler.py
+++ b/modules/FIC_FileHandler.py
@@ -248,3 +248,9 @@ class FICFileHandler(FICLogger, FICDataVault):
                                  .format(self.construct_path(old_path, old_file)) +
                                  "or the final location \"{}\" has not been created"
                                  .format(self.construct_path(new_path, new_file)))
+
+    def last_checked(self, repo_name):
+        return json.load(self.load(CHANGELOG_REPO_PATH, repo_name.lower() + ".json")).get("0").get("last_release").get("date")
+
+    def local_version(self, repo_name):
+        return json.load(self.load(CHANGELOG_REPO_PATH, repo_name.lower() + ".json")).get("0").get("last_release").get("version")

--- a/modules/FIC_FileHandler.py
+++ b/modules/FIC_FileHandler.py
@@ -251,10 +251,8 @@ class FICFileHandler(FICLogger, FICDataVault):
 
     @staticmethod
     def remove_first_element(dictionary):
-        try:
+        if next(iter(dictionary)) == 0:
             del dictionary["0"]
-        except KeyError:
-            pass
 
     def last_checked(self):
         self.last_check = json.load(self.load(CHANGELOG_REPO_PATH, self.repo_name.lower() + ".json")).get("0").get("last_checked")

--- a/modules/FIC_FileHandler.py
+++ b/modules/FIC_FileHandler.py
@@ -129,9 +129,6 @@ class FICFileHandler(FICLogger, FICDataVault):
             hg_repos = [repo for repo in files_to_check["Mercurial"].keys()]
         return git_repos, hg_repos
 
-    def _extract_repo_type(self, repo_name):
-        return json.load(self.load(None, "repositories.json")).get("Github").get(repo_name).get("configuration").get("type")
-
     @staticmethod
     def partition_string(word):
         head, sep, tail = word.partition(".")
@@ -298,9 +295,6 @@ class FICFileHandler(FICLogger, FICDataVault):
     def remove_first_element(dictionary):
         if next(iter(dictionary)) == 0:
             del dictionary["0"]
-
-    def last_checked(self):
-        self.last_check = json.load(self.load(CHANGELOG_REPO_PATH, self.repo_name.lower() + ".json")).get("0").get("last_checked")
 
     def handle_first_element(self):
         if self.repo_type is None:

--- a/modules/FIC_FileHandler.py
+++ b/modules/FIC_FileHandler.py
@@ -249,14 +249,40 @@ class FICFileHandler(FICLogger, FICDataVault):
                                  "or the final location \"{}\" has not been created"
                                  .format(self.construct_path(new_path, new_file)))
 
-    def update_json(self, repo_name):
-        local_json_data = json.load(self.load(CHANGELOG_REPO_PATH, repo_name.lower() + ".json"))
+    @staticmethod
+    def delete_element_0(dictionary):
         try:
-            del local_json_data["0"]
+            del dictionary["0"]
         except KeyError:
             pass
+
+    def last_checked(self):
+        self.last_check = json.load(self.load(CHANGELOG_REPO_PATH, self.repo_name.lower() + ".json")).get("0").get("last_checked")
+
+    def handle_element_0(self):
+        if self.repo_type is None:
+            self.add_element_0_hg()
+        elif self.repo_type is not None:
+            self.add_element_0_git()
+        else:
+            exit(12)
+
+    def update_json(self, repo_name):
+        self.handle_element_0()
+        local_json_data = json.load(self.load(CHANGELOG_REPO_PATH, repo_name.lower() + ".json"))
+        self.delete_element_0(local_json_data)
         for key in local_json_data.keys():
             self.commit_number += 1
-            print(self.commit_number)
             self.list_of_commits.update({self.commit_number: local_json_data[key]})
-        print(self.list_of_commits)
+        self.save("data", "lol.json", self.list_of_commits)
+
+    def add_element_0_git(self):
+        if self.repo_type == "tag":
+            self.list_of_commits.update({"0": {"last_checked: ": self.last_check,
+                                               "version: ": self.local_version}})
+        else:
+            self.list_of_commits.update({"0": {"last_checked: ": self.last_check}})
+
+    def add_element_0_hg(self):
+        self.list_of_commits.update({"0": {"last_push_id": self.last_local_push_id}})
+

--- a/modules/FIC_FileHandler.py
+++ b/modules/FIC_FileHandler.py
@@ -250,7 +250,7 @@ class FICFileHandler(FICLogger, FICDataVault):
                                  .format(self.construct_path(new_path, new_file)))
 
     def last_checked(self, repo_name):
-        return json.load(self.load(CHANGELOG_REPO_PATH, repo_name.lower() + ".json")).get("0").get("last_release").get("date")
+        return json.load(self.load(CHANGELOG_REPO_PATH, repo_name.lower() + ".json")).get("0").get("last_checked")
 
     def local_version(self, repo_name):
         return json.load(self.load(CHANGELOG_REPO_PATH, repo_name.lower() + ".json")).get("0").get("last_release").get("version")

--- a/modules/FIC_Github.py
+++ b/modules/FIC_Github.py
@@ -110,3 +110,7 @@ class FICGithub(FICLogger):
             self.LOGGER.info("Summary of commit {}".format(FICGithub.commit(self)))
             self.LOGGER.info("pushing changes to {}  on branch  {}".format(self.repo.remotes.origin.url, self.repo.active_branch))
             self.LOGGER.info("Summary of push: {}".format(self.repo.remotes.origin.push(refspec=self.repo.active_branch)[0].summary))
+
+    def revert_modified_files(self):
+        from modules.config import CHANGELOG_JSON_PATH, CHANGELOG_MD_PATH, CHANGELOG_REPO_PATH
+        return self.repo.git.checkout([CHANGELOG_JSON_PATH, CHANGELOG_MD_PATH, CHANGELOG_REPO_PATH])

--- a/modules/FIC_Github.py
+++ b/modules/FIC_Github.py
@@ -183,7 +183,7 @@ class FICGithub(FICFileHandler, FICLogger, FICDataVault):
         self.last_check = json.load(self.load(CHANGELOG_REPO_PATH, self.repo_name.lower() + ".json")).get("0").get("last_checked")
 
     def local_version(self):
-        self.release_date = json.load(self.load(CHANGELOG_REPO_PATH, self.repo_name.lower() + ".json")).get("0").get("last_release").get("version")
+        self.local_version = json.load(self.load(CHANGELOG_REPO_PATH, self.repo_name.lower() + ".json")).get("0").get("last_release").get("version")
 
     def not_tag(self):
         pass
@@ -216,9 +216,10 @@ class FICGithub(FICFileHandler, FICLogger, FICDataVault):
     # the main method to iterate through the commits
     def commit_iterator(self):
         for current_commit in self.repo_data.commits(since=self.last_check, until=self.release_date):
+            self.commit_number += 1
             self.store_data(current_commit)
             self.construct_commit()
-            self.commit_number += 1
+
 
     # the main method to iterate through the Git repository
     def repo_iterator(self):

--- a/modules/FIC_Github.py
+++ b/modules/FIC_Github.py
@@ -126,9 +126,6 @@ class FICGithub(FICFileHandler, FICLogger, FICDataVault):
     def get_repo_url(self):
         return self.repo_data.svn_url
 
-    def _extract_repo_type(self):
-        return json.load(self.load(None, "repositories.json")).get("Github").get(self.repo_name).get("configuration").get("type")
-
     def _repo_team(self):
         self.team_name = json.load(self.load(None, "repositories.json")).get("Github").get(self.repo_name).get("team")
 
@@ -252,7 +249,7 @@ class FICGithub(FICFileHandler, FICLogger, FICDataVault):
         self.bump_version = None
 
     def start(self):
-        self.repo_type = self._extract_repo_type()
+        self.repo_type = self._extract_repo_type(self.repo_name)
         self._repo_team()
         self.read_repo()
         self._repo_files()

--- a/modules/FIC_Github.py
+++ b/modules/FIC_Github.py
@@ -258,4 +258,3 @@ class FICGithub(FICFileHandler, FICLogger, FICDataVault):
         self._repo_files()
         self._repo_switcher()
         self.update_json(self.repo_name)
-        self.list_of_commits = {}

--- a/modules/FIC_Github.py
+++ b/modules/FIC_Github.py
@@ -14,12 +14,11 @@ import json
 
 class FICGithub(FICFileHandler, FICLogger, FICDataVault):
 
-    def __init__(self, repo_name):
+    def __init__(self):
         FICLogger.__init__(self)
         FICFileHandler.__init__(self)
         FICDataVault.__init__(self)
         self.team_name = None
-        self.repo_name = repo_name
         self.token_counter = 0
         self._get_os_var()
         self._token = os.environ.get(GIT_TOKEN[self.token_counter])
@@ -132,8 +131,14 @@ class FICGithub(FICFileHandler, FICLogger, FICDataVault):
     def _repo_files(self):
         self.folders_to_check = json.load(self.load(None, "repositories.json")).get("Github").get(self.repo_name).get("configuration").get("folders-to-check")
 
+    def _extract_repo_type(self, repo_name):
+        return json.load(self.load(None, "repositories.json")).get("Github").get(repo_name).get("configuration").get("type")
+
     def _local_version(self):
         self.local_version = json.load(self.load(CHANGELOG_REPO_PATH, self.repo_name.lower() + ".json")).get("0").get("last_release").get("version")
+
+    def _last_checked(self):
+        self.last_check = json.load(self.load(CHANGELOG_REPO_PATH, self.repo_name.lower() + ".json")).get("0").get("last_checked")
 
     def _get_sha(self, commit):
         self.commit_sha = commit.sha
@@ -203,22 +208,22 @@ class FICGithub(FICFileHandler, FICLogger, FICDataVault):
             self._construct_commit()
 
     def _not_tag(self):
-        self.last_checked()
+        self._last_checked()
         self.release_date = None
         self._commit_iterator()
 
     def _build_puppet(self):
-        self.last_checked()
+        self._last_checked()
         self.release_date = None
         self._commit_iterator()
 
     def _tag(self):
-        self.last_checked()
+        self._last_checked()
         self.release_date = None
         self._commit_iterator()
 
     def _commit_keyword(self):
-        self.last_checked()
+        self._last_checked()
         self.keyword = 'deploy'
         self._commit_iterator()
 

--- a/modules/FIC_Github.py
+++ b/modules/FIC_Github.py
@@ -8,6 +8,7 @@ from modules.config import GIT_TOKEN
 from git import Repo
 import os
 import json
+from modules.FIC_DataVault import FICDataVault
 
 
 class FICGithub(FICFileHandler, FICLogger):
@@ -15,6 +16,7 @@ class FICGithub(FICFileHandler, FICLogger):
     def __init__(self, team_name, repo_name):
         FICLogger.__init__(self)
         FICFileHandler.__init__(self)
+        FICDataVault.__init__(self)
         self.team_name = team_name
         self.repo_name = repo_name
         self.token_counter = 0
@@ -127,8 +129,28 @@ class FICGithub(FICFileHandler, FICLogger):
     def repo_type(self):
         return json.load(self.load(None, "repositories.json")).get("Github").get(self.repo_name).get("configuration").get("type")
 
+    def extract_commit_data(self):
+        for commit in self.repo_data.commits():
+            self.commit_message = commit.message
+            self.commit_date = commit.commit.author.get("date")
+            self.commit_sha = commit.sha
+            self.commit_author = commit.commit.author.get("name")
+            self.commit_author_email = commit.commit.author.get("email")
+            # self.commit_files_changed =
+            self.commit_url = commit.url
+            # following lines are for testing purposes only
+            print(self.commit_author_email)
+            print(self.commit_url)
+            print(self.commit_date)
+            print(self.commit_message)
+            print(self.commit_author)
+            print(self.commit_sha)
+            print("\n")
 
-# for testing
+
+# # for testing
 a = FICGithub('mozilla-releng', 'OpenCloudConfig')
 print(a.get_repo_url())
-print(a.repo_type())
+print(a.repo_type(), "\n")
+
+a.extract_commit_data()

--- a/modules/FIC_Github.py
+++ b/modules/FIC_Github.py
@@ -11,7 +11,7 @@ import json
 from modules.FIC_DataVault import FICDataVault
 
 
-class FICGithub(FICFileHandler, FICLogger):
+class FICGithub(FICFileHandler, FICLogger, FICDataVault):
 
     def __init__(self, team_name, repo_name):
         FICLogger.__init__(self)
@@ -136,7 +136,7 @@ class FICGithub(FICFileHandler, FICLogger):
             self.commit_sha = commit.sha
             self.commit_author = commit.commit.author.get("name")
             self.commit_author_email = commit.commit.author.get("email")
-            # self.commit_files_changed =
+            # self.commit_files_changed = can not find this data in the returned shortcommit
             self.commit_url = commit.url
             # following lines are for testing purposes only
             print(self.commit_author_email)

--- a/modules/config.py
+++ b/modules/config.py
@@ -4,7 +4,7 @@ CHANGELOG_JSON_PATH = "changelog.json"
 CHANGELOG_MD_PATH   = "changelog.md"
 CHANGELOG_REPO_PATH = "data"
 LOG_FILE_PATH       = "LOG.log"
-GIT_TOKEN           = "GIT_TOKEN"  # Name of OS.ENV from which to pull the Github Token
+GIT_TOKEN           = ["GIT_TOKEN"]  # Name of OS.ENV from which to pull the Github Token
 
 # Default values, if nothing is offered, fall back to these.
 DEFAULT_REPO_CHOICE       = "ALL"

--- a/repositories.json
+++ b/repositories.json
@@ -3,7 +3,7 @@
     "OpenCloudConfig": {
       "name": "Open Cloud Config",
       "url": "https://github.com/mozilla-releng/OpenCloudConfig",
-      "team": "mozilla-releng/",
+      "team": "mozilla-releng",
       "top-contributors": [" ", " "],
       "order": 7,
       "configuration": {
@@ -14,7 +14,7 @@
     "build-cloud-tools": {
       "name": "Build Cloud Tools",
       "url": "https://github.com/mozilla-releng/build-cloud-tools",
-      "team": "mozilla-releng/",
+      "team": "mozilla-releng",
       "top-contributors": [" ", " "],
       "order": 25,
       "configuration": {
@@ -25,7 +25,7 @@
     "taskcluster": {
       "name": "Taskcluster",
       "url": "https://github.com/taskcluster/taskcluster",
-      "team": "taskcluster/",
+      "team": "taskcluster",
       "top-contributors": [" ", " "],
       "order": 13,
       "configuration": {
@@ -36,7 +36,7 @@
     "services": {
       "name": "Release Services",
       "url": "https://github.com/mozilla/release-services",
-      "team": "mozilla/",
+      "team": "mozilla",
       "top-contributors": [" ", " "],
       "order": 24,
       "configuration": {
@@ -51,7 +51,7 @@
     "build-puppet": {
       "name": "Build Puppet",
       "url": "https://github.com/mozilla/build-puppet",
-      "team": "mozilla-releng/",
+      "team": "mozilla-releng",
       "order": 12,
       "configuration": {
         "type": "tag",
@@ -74,7 +74,7 @@
     "mozapkpublisher": {
       "name": "MozAPK Publisher",
       "url": "https://github.com/mozilla-releng/mozapkpublisher",
-      "team": "mozilla-releng/",
+      "team": "mozilla-releng",
       "top-contributors": [" ", " "],
       "order": 28,
       "configuration": {
@@ -86,7 +86,7 @@
     "beetmoverscript": {
       "name": "Beetmover Script",
       "url": "https://github.com/mozilla-releng/beetmoverscript",
-      "team": "mozilla-releng/",
+      "team": "mozilla-releng",
       "top-contributors": [" ", " "],
       "order": 14,
       "configuration": {
@@ -98,7 +98,7 @@
     "addonscript": {
       "name": "Addon Script",
       "url": "https://github.com/mozilla-releng/addonscript",
-      "team": "mozilla-releng/",
+      "team": "mozilla-releng",
       "top-contributors": [" ", " "],
       "order": 15,
       "configuration": {
@@ -110,7 +110,7 @@
     "shipitscript": {
       "name": "Shipit Script",
       "url": "https://github.com/mozilla-releng/shipitscript",
-      "team": "mozilla-releng/",
+      "team": "mozilla-releng",
       "top-contributors": [" ", " "],
       "order": 18,
       "configuration": {
@@ -122,7 +122,7 @@
     "bouncerscript": {
       "name": "Bouncer Script",
       "url": "https://github.com/mozilla-releng/bouncerscript",
-      "team": "mozilla-releng/",
+      "team": "mozilla-releng",
       "top-contributors": [" ", " "],
       "order": 19,
       "configuration": {
@@ -134,7 +134,7 @@
     "treescript": {
       "name": "Tree Script",
       "url": "https://github.com/mozilla-releng/treescript",
-      "team": "mozilla-releng/",
+      "team": "mozilla-releng",
       "top-contributors": [" ", " "],
       "order": 21,
       "configuration": {
@@ -146,7 +146,7 @@
     "scriptworker": {
       "name": "Script Worker",
       "url": "https://github.com/mozilla-releng/scriptworker",
-      "team": "mozilla-releng/",
+      "team": "mozilla-releng",
       "top-contributors": [" ", " "],
       "order": 20,
       "configuration": {
@@ -158,7 +158,7 @@
     "pushsnapscript": {
       "name": "Pushsnap Script",
       "url": "https://github.com/mozilla-releng/pushsnapscript",
-      "team": "mozilla-releng/",
+      "team": "mozilla-releng",
       "top-contributors": [" ", " "],
       "order": 16,
       "configuration": {
@@ -170,7 +170,7 @@
     "signingscript": {
       "name": "Signing Script",
       "url": "https://github.com/mozilla-releng/signingscript",
-      "team": "mozilla-releng/",
+      "team": "mozilla-releng",
       "top-contributors": [" ", " "],
       "order": 22,
       "configuration": {
@@ -182,7 +182,7 @@
     "pushapkscript": {
       "name": "Pushapk Script",
       "url": "https://github.com/mozilla-releng/pushapkscript",
-      "team": "mozilla-releng/",
+      "team": "mozilla-releng",
       "top-contributors": [" ", " "],
       "order": 17,
       "configuration": {
@@ -194,7 +194,7 @@
     "balrogscript": {
       "name": "Balrog Script",
       "url": "https://github.com/mozilla-releng/balrogscript",
-      "team": "mozilla-releng/",
+      "team": "mozilla-releng",
       "top-contributors": [" ", " "],
       "order": 11,
       "configuration": {
@@ -206,7 +206,7 @@
     "signtool": {
       "name": "Signtool",
       "url": "https://github.com/mozilla-releng/signtool",
-      "team": "mozilla-releng/",
+      "team": "mozilla-releng",
       "top-contributors": [" ", " "],
       "order": 23,
       "configuration": {
@@ -218,7 +218,7 @@
     "relops-image-builder": {
       "name": "Relops-Image-Builder",
       "url": "https://github.com/mozilla-platform-ops/relops-image-builder",
-      "team": "mozilla-platform-ops/",
+      "team": "mozilla-platform-ops",
       "top-contributors": [" ", " "],
       "order": 6,
       "configuration": {
@@ -229,7 +229,7 @@
     "relops-hardware-controller": {
       "name": "Relops-Hardware-Controller",
       "url": "https://github.com/mozilla-platform-ops/relops-hardware-controller",
-      "team": "mozilla-platform-ops/",
+      "team": "mozilla-platform-ops",
       "top-contributors": [" ", " "],
       "order": 8,
       "configuration": {
@@ -240,7 +240,7 @@
     "ronin_puppet": {
       "name": "Ronin-Puppet",
       "url": "https://github.com/mozilla-platform-ops/ronin_puppet",
-      "team": "mozilla-platform-ops/",
+      "team": "mozilla-platform-ops",
       "top-contributors": [" ", " "],
       "order": 9,
       "configuration": {


### PR DESCRIPTION
This PR contains the implementation of Issue #438 
start() method is the access to the logic. It requires the repo_name and will return a dictionary with the commits. 
!!! the code will not work until:
 -- the .json files will be generated and will contain the last_checked value: def last_checked(self): returns the last check date from .json files

this is how to call the logic:

# the main method to iterate through the Git repository
b = FICFileHandler()
for repo in json.load(b.load(None, "repositories.json")).get("Github"):
    a = FICGithub(repo)
    a.start()
