### PR TITLE
Issue 438 - ( rewrited a part of PR #443 ) the logic that manage the commits from github repositories ( OOP )

### DIFF
--- a/modules/FIC_DataVault.py
+++ b/modules/FIC_DataVault.py
@@ -34,5 +34,6 @@ class FICDataVault:
         # GIT Specific values
         self.folders_to_check     = []
         self.repo_type            = None
+        self.local_version        = None
 
 

--- a/modules/FIC_DataVault.py
+++ b/modules/FIC_DataVault.py
@@ -37,5 +37,6 @@ class FICDataVault:
         self.repo_type            = None
         self.local_version        = None
         self.release_version      = None
+        self.build_puppet_version = None
         self.list_of_commits      = {}
         self.keyword = None

--- a/modules/FIC_DataVault.py
+++ b/modules/FIC_DataVault.py
@@ -36,5 +36,6 @@ class FICDataVault:
         self.folders_to_check     = []
         self.repo_type            = None
         self.local_version        = None
+        self.release_version      = None
 
 

--- a/modules/FIC_DataVault.py
+++ b/modules/FIC_DataVault.py
@@ -21,13 +21,17 @@ class FICDataVault:
         self.commit_date          = None
         self.commit_files_changed = None
         self.repo_name            = None
+        self.team_name            = None
 
         # HG Specific values
-        self.changeset_index  = None
-        self.changeset = None
-        self.changeset_lander = None
-        self.hg_commits_list = None
-        self.changesets_json = None
-        self.constructed_dict = {}
+        self.changeset_index      = None
+        self.changeset            = None
+        self.changeset_lander     = None
+        self.hg_commits_list      = None
+        self.changesets_json      = None
+        self.constructed_dict     = {}
+
+        # GIT Specific values
+        self.folders_to_check     = []
 
 

--- a/modules/FIC_DataVault.py
+++ b/modules/FIC_DataVault.py
@@ -20,6 +20,7 @@ class FICDataVault:
         self.commit_message       = None
         self.commit_date          = None
         self.commit_files_changed = None
+        self.repo_name            = None
 
         # HG Specific values
         self.changeset_index  = None

--- a/modules/FIC_DataVault.py
+++ b/modules/FIC_DataVault.py
@@ -22,6 +22,7 @@ class FICDataVault:
         self.commit_files_changed = None
         self.repo_name            = None
         self.team_name            = None
+        self.last_check           = None
 
         # HG Specific values
         self.changeset_index      = None

--- a/modules/FIC_DataVault.py
+++ b/modules/FIC_DataVault.py
@@ -38,5 +38,4 @@ class FICDataVault:
         self.local_version        = None
         self.release_version      = None
         self.list_of_commits      = {}
-
-
+        self.keyword = None

--- a/modules/FIC_DataVault.py
+++ b/modules/FIC_DataVault.py
@@ -37,5 +37,6 @@ class FICDataVault:
         self.repo_type            = None
         self.local_version        = None
         self.release_version      = None
+        self.list_of_commits      = {}
 
 

--- a/modules/FIC_DataVault.py
+++ b/modules/FIC_DataVault.py
@@ -33,5 +33,6 @@ class FICDataVault:
 
         # GIT Specific values
         self.folders_to_check     = []
+        self.repo_type            = None
 
 

--- a/modules/FIC_Exceptions.py
+++ b/modules/FIC_Exceptions.py
@@ -5,10 +5,10 @@ from modules.FIC_Github import FICGithub
 
 
 class FICExceptions(FICGithub):
-    def __init__(self, error):
+    def __init__(self):
         self.SIGINT = False
         FICGithub.__init__(self)
-        self.e = int(error)
+        self.e = None
 
     def signal_handler(self, signal, frame):
         self.LOGGER.info("KeyboardInterrupt (ID: {}) has been caught. Cleaning up...".format(signal))
@@ -16,7 +16,8 @@ class FICExceptions(FICGithub):
         self.revert_modified_files()
         exit(10)
 
-    def handle_git_exception(self):
+    def handle_git_exception(self, error):
+        self.e = error
         if self.e == 301:
             self.LOGGER.critical("Error code 301: Moved Permanently")
             exit(301)

--- a/modules/FIC_FileHandler.py
+++ b/modules/FIC_FileHandler.py
@@ -101,9 +101,9 @@ class FICFileHandler(FICLogger, FICDataVault):
     def _generate_first_element_git(self, repo_type=None):
         repo_type = repo_type if repo_type else self._extract_repo_type()
         if repo_type == "tag":
-            return {"0": {"last_checked": return_time("%Y-%m-%d %H:%M:%S", "sub", 2), "version": self.local_version}}
+            return {"0": {"last_checked": return_time("%Y-%m-%dT%H:%M:%S.%f", "sub", 2), "version": self.local_version}}
         else:
-            return {"0": {"last_checked": return_time("%Y-%m-%d %H:%M:%S", "sub", 2)}}
+            return {"0": {"last_checked": return_time("%Y-%m-%dT%H:%M:%S.%f", "sub", 2)}}
 
     def _generate_first_element_hg(self):
         return {"0": {"last_push_id": "2019-04-12"}}
@@ -134,7 +134,10 @@ class FICFileHandler(FICLogger, FICDataVault):
             f.close()
 
     def construct_path(self, directory_name, file_name):
-        if directory_name is None:
+        if (directory_name is None) and (file_name is None):
+            return self._check_dev_mode()
+
+        elif directory_name is None:
             path = os.path.join(self.path_level, file_name)
             return path
         else:

--- a/modules/FIC_FileHandler.py
+++ b/modules/FIC_FileHandler.py
@@ -114,7 +114,7 @@ class FICFileHandler(FICLogger, FICDataVault):
     def _check_module_files(self):
         self._missing_files = []
         needed_files = ["config.py", "FIC_DataVault.py", "FIC_Exceptions.py", "FIC_FileHandler.py",
-                        "FIC_Filters.py", "FIC_Github.py", "FIC_Logger.py", "FIC_MainMenu.py",
+                        "FIC_Github.py", "FIC_Logger.py", "FIC_MainMenu.py",
                         "FIC_Mercurial.py"]
 
         for file in needed_files:

--- a/modules/FIC_FileHandler.py
+++ b/modules/FIC_FileHandler.py
@@ -6,6 +6,7 @@ from modules.FIC_DataVault import FICDataVault
 from modules.config import *
 import json
 import os
+from modules.FIC_Utilities import return_time
 
 
 class FICFileHandler(FICLogger, FICDataVault):
@@ -73,24 +74,42 @@ class FICFileHandler(FICLogger, FICDataVault):
             # Check all Github files exist for each repository.
             for key in files_to_check["Github"].keys():
                 if not os.path.exists(os.path.join(self.path_level, CHANGELOG_REPO_PATH, key.lower() + ".json")):
-                    self._missing_files.append(key.lower() + ".json")
+                    self._missing_files.append((key.lower() + ".json", "git"))
 
                 if not os.path.exists(os.path.join(self.path_level, CHANGELOG_REPO_PATH, key.lower() + ".md")):
-                    self._missing_files.append(key.lower() + ".md")
+                    self._missing_files.append((key.lower() + ".md", "git"))
 
             # Check all Mercurial files exist for each repository.
             for key in files_to_check["Mercurial"].keys():
                 if not os.path.exists(os.path.join(self.path_level, CHANGELOG_REPO_PATH, key.lower() + ".json")):
-                    self._missing_files.append(key.lower() + ".json")
+                    self._missing_files.append((key.lower() + ".json", "hg"))
                 if not os.path.exists(os.path.join(self.path_level, CHANGELOG_REPO_PATH, key.lower() + ".md")):
-                    self._missing_files.append(key.lower() + ".md")
+                    self._missing_files.append((key.lower() + ".md", "hg"))
 
         if self._missing_files:
             self._create_missing_repo_files()
 
     def _create_missing_repo_files(self):
         for file_to_create in self._missing_files:
-            open(os.path.abspath(os.path.join(self.path_level, CHANGELOG_REPO_PATH, file_to_create.lower())), "w").close()
+            new_local_file = open(self.construct_path(CHANGELOG_REPO_PATH, file_to_create[0].lower()), "w")
+            if file_to_create[1] == "git" and file_to_create[0].endswith(".json"):
+                self.save(CHANGELOG_REPO_PATH, file_to_create[0], self._generate_first_element_git())
+            elif file_to_create[1] == "hg" and file_to_create[0].endswith(".json"):
+                self.save(CHANGELOG_REPO_PATH, file_to_create[0], self._generate_first_element_hg())
+            new_local_file.close()
+
+    def _generate_first_element_git(self, repo_type=None):
+        repo_type = repo_type if repo_type else self._extract_repo_type()
+        if repo_type == "tag":
+            return {"0": {"last_checked": return_time("%Y-%m-%d %H:%M:%S", "sub", 2), "version": self.local_version}}
+        else:
+            return {"0": {"last_checked": return_time("%Y-%m-%d %H:%M:%S", "sub", 2)}}
+
+    def _generate_first_element_hg(self):
+        return {"0": {"last_push_id": "2019-04-12"}}
+
+    def _extract_repo_type(self):
+        return json.load(self.load(None, "repositories.json")).get("Github").get(self.repo_name).get("configuration").get("type")
 
     def _check_module_files(self):
         self._missing_files = []

--- a/modules/FIC_Github.py
+++ b/modules/FIC_Github.py
@@ -114,3 +114,6 @@ class FICGithub(FICLogger):
     def revert_modified_files(self):
         from modules.config import CHANGELOG_JSON_PATH, CHANGELOG_MD_PATH, CHANGELOG_REPO_PATH
         return self.repo.git.checkout([CHANGELOG_JSON_PATH, CHANGELOG_MD_PATH, CHANGELOG_REPO_PATH])
+
+    def get_repo_url(self):
+        return self.repo_data.svn_url

--- a/modules/FIC_Github.py
+++ b/modules/FIC_Github.py
@@ -139,3 +139,44 @@ class FICGithub(FICFileHandler, FICDataVault):
 
     def _get_release(self):
         self.release_version = [tag for tag in self.repo_data.tags(number=1)][0].name
+
+    def _commit_iterator(self):
+        self.commit_number = 0
+        for current_commit in self.repo_data.commits(since=self.last_check):
+            self.commit_number += 1
+            self._store_data(current_commit)
+        #     self._commit_filter()
+        # self.keyword = None
+        # self.bump_version = None
+
+    def _store_data(self, current_commit):
+        self._get_sha(current_commit)
+        self._get_message(current_commit)
+        self._get_date(current_commit)
+        self._get_author(current_commit)
+        self._get_author_email(current_commit)
+        self._get_url(current_commit)
+        self._get_files()
+
+    def _get_sha(self, commit):
+        self.commit_sha = commit.sha
+
+    def _get_message(self, commit):
+        self.commit_message = commit.message
+
+    def _get_date(self, commit):
+        self.commit_date = commit.commit.author.get("date")
+
+    def _get_author(self, commit):
+        self.commit_author = commit.commit.author.get("name")
+
+    def _get_author_email(self, commit):
+        self.commit_author_email = commit.commit.author.get("email")
+
+    def _get_url(self, commit):
+        self.commit_url = commit.url
+
+    def _get_files(self):
+        self.commit_files_changed = []
+        for item in (range(len(self.repo_data.commit(sha=self.commit_sha).files))):
+            self.commit_files_changed.append(self.repo_data.commit(sha=self.commit_sha).files[item].get('filename'))

--- a/modules/FIC_Github.py
+++ b/modules/FIC_Github.py
@@ -145,9 +145,8 @@ class FICGithub(FICFileHandler, FICDataVault):
         for current_commit in self.repo_data.commits(since=self.last_check):
             self.commit_number += 1
             self._store_data(current_commit)
-        #     self._commit_filter()
-        # self.keyword = None
-        # self.bump_version = None
+            self._commit_filter()
+        self.keyword = None
 
     def _store_data(self, current_commit):
         self._get_sha(current_commit)
@@ -195,3 +194,20 @@ class FICGithub(FICFileHandler, FICDataVault):
                                                           'message': self.commit_message,
                                                           'date': self.commit_date,
                                                           'files': self.commit_files_changed}})
+
+    def _commit_filter(self):
+        if self.repo_type == "commit-keyword":
+            if self.keyword in self.commit_message:
+                self._construct_commit()
+
+        elif self.repo_type == "tag":
+            if self.repo_name == "build-puppet":
+                self._construct_commit()
+            elif self.release_version in self.commit_message:
+                self._construct_commit()
+
+        elif len(self.folders_to_check) > 0 and self._compare_files():
+            self._construct_commit()
+
+        else:
+            self._construct_commit()

--- a/modules/FIC_Github.py
+++ b/modules/FIC_Github.py
@@ -22,7 +22,7 @@ class FICGithub(FICFileHandler, FICDataVault):
         self._token = os.environ.get(GIT_TOKEN[self.token_counter])
         self._gh = self._auth()
         self.repo_data = None
-        self.repo = Repo("..")
+        self.repo = self.construct_path(None, None)
 
     def _auth(self):
         return github3.login(token=self._token)

--- a/modules/FIC_Github.py
+++ b/modules/FIC_Github.py
@@ -159,13 +159,13 @@ class FICGithub(FICFileHandler, FICDataVault):
             return False
 
     def _last_checked(self):
-        self.last_check = json.load(self.load(CHANGELOG_REPO_PATH, self.repo_name.lower() + ".json")).get("0").get("last_checked")
+        import datetime
+        self.last_check = datetime.datetime.strptime(json.load(self.load(CHANGELOG_REPO_PATH, self.repo_name.lower() + ".json")).get("0").get("last_checked"), "%Y-%m-%d %H:%M:%S")
 
     def _commit_iterator(self):
         self.commit_number = 0
         for current_commit in self.repo_data.commits(since=self.last_check):
-            self._store_data(current_commit)
-            self._commit_filter()
+            self._commit_filter(current_commit)
         self.keyword = None
 
     def _store_data(self, current_commit):
@@ -215,26 +215,31 @@ class FICGithub(FICFileHandler, FICDataVault):
                                                           'date': self.commit_date,
                                                           'files': self.commit_files_changed}})
 
-    def _commit_filter(self):
+    def _commit_filter(self, commit_content):
         if self.repo_type == "commit-keyword":
             if self.keyword in self.commit_message:
                 self.commit_number += 1
+                self._store_data(commit_content)
                 self._construct_commit()
 
         elif self.repo_type == "tag":
             if self.repo_name == "build-puppet":
                 self.commit_number += 1
+                self._store_data(commit_content)
                 self._construct_commit()
             elif self.release_version in self.commit_message:
                 self.commit_number += 1
+                self._store_data(commit_content)
                 self._construct_commit()
 
         elif len(self.folders_to_check) > 0 and self._compare_files():
             self.commit_number += 1
+            self._store_data(commit_content)
             self._construct_commit()
 
         else:
             self.commit_number += 1
+            self._store_data(commit_content)
             self._construct_commit()
 
     def _not_tag(self):
@@ -261,7 +266,7 @@ class FICGithub(FICFileHandler, FICDataVault):
         self.keyword = 'deploy'
         self._commit_iterator()
 
-    def _repo_switcher(self):
+    def _repo_type_checker(self):
         if self.repo_type == "no-tag":
             self._not_tag()
 
@@ -281,6 +286,6 @@ class FICGithub(FICFileHandler, FICDataVault):
         self._repo_team()
         self.read_repo()
         self._repo_files()
-        self._repo_switcher()
-        self.save('data', self.repo_name, self.list_of_commits)  # write the json
+        self._repo_type_checker()
+        self.save(CHANGELOG_REPO_PATH, self.repo_name + ".json", self.list_of_commits)  # write the json
         self.list_of_commits = {}

--- a/modules/FIC_Github.py
+++ b/modules/FIC_Github.py
@@ -180,3 +180,9 @@ class FICGithub(FICFileHandler, FICDataVault):
         self.commit_files_changed = []
         for item in (range(len(self.repo_data.commit(sha=self.commit_sha).files))):
             self.commit_files_changed.append(self.repo_data.commit(sha=self.commit_sha).files[item].get('filename'))
+
+    def _compare_files(self):
+        for folder_to_check in range(len(self.folders_to_check)):
+            for changed_folder in range(len(self.commit_files_changed)):
+                if str(self.folders_to_check[folder_to_check]) in str(self.commit_files_changed[changed_folder]):
+                    return True

--- a/modules/FIC_Github.py
+++ b/modules/FIC_Github.py
@@ -126,3 +126,7 @@ class FICGithub(FICFileHandler, FICDataVault):
 
     def _repo_files(self):
         self.folders_to_check = json.load(self.load(None, "repositories.json")).get("Github").get(self.repo_name).get("configuration").get("folders-to-check")
+
+    def _extract_repo_type(self):
+        self.repo_type = json.load(self.load(None, "repositories.json")).get("Github").get(self.repo_name).get("configuration").get("type")
+

--- a/modules/FIC_Github.py
+++ b/modules/FIC_Github.py
@@ -24,8 +24,8 @@ class FICGithub(FICFileHandler, FICDataVault):
     def _auth(self):
         return github3.login(token=self._token)
 
-    def read_repo(self, team_name, repo_name):
-        return self._init_github(self._gh, team_name, repo_name)
+    def read_repo(self):
+        return self._init_github(self._gh, self.team_name, self.repo_name)
 
     def _init_github(self, *args):
         self.repo_data = github3.GitHub.repository(args[0], args[1], args[2])
@@ -123,3 +123,6 @@ class FICGithub(FICFileHandler, FICDataVault):
 
     def _repo_team(self):
         self.team_name = json.load(self.load(None, "repositories.json")).get("Github").get(self.repo_name).get("team")
+
+    def _repo_files(self):
+        self.folders_to_check = json.load(self.load(None, "repositories.json")).get("Github").get(self.repo_name).get("configuration").get("folders-to-check")

--- a/modules/FIC_Github.py
+++ b/modules/FIC_Github.py
@@ -136,3 +136,6 @@ class FICGithub(FICFileHandler, FICDataVault):
 
     def _last_checked(self):
         self.last_check = json.load(self.load(CHANGELOG_REPO_PATH, self.repo_name.lower() + ".json")).get("0").get("last_checked")
+
+    def _get_release(self):
+        self.release_version = [tag for tag in self.repo_data.tags(number=1)][0].name

--- a/modules/FIC_Github.py
+++ b/modules/FIC_Github.py
@@ -211,3 +211,36 @@ class FICGithub(FICFileHandler, FICDataVault):
 
         else:
             self._construct_commit()
+
+    def _not_tag(self):
+        self._last_checked()
+        self._commit_iterator()
+
+    def _build_puppet(self):
+        self._last_checked()
+        self._commit_iterator()
+
+    def _tag(self):
+        self._last_checked()
+        self._commit_iterator()
+
+    def _commit_keyword(self):
+        self._last_checked()
+        self.keyword = 'deploy'
+        self._commit_iterator()
+
+    def _repo_switcher(self):
+        if self.repo_type == "no-tag":
+            self._not_tag()
+
+        elif self.repo_type == "tag":
+            if self.repo_name == "build-puppet":
+                self._build_puppet()
+            else:
+                self._get_release()
+                self._tag()
+
+        elif self.repo_type == "commit-keyword":
+            self._commit_keyword()
+        else:
+            print("Repo type not defined for %s", self.repo_name)

--- a/modules/FIC_Github.py
+++ b/modules/FIC_Github.py
@@ -2,15 +2,18 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 import github3
-from modules.FIC_Logger import FICLogger
+from modules.FIC_FileHandler import FICFileHandler
+from modules.FIC_DataVault import FICDataVault
 from modules.config import GIT_TOKEN
 from git import Repo
 import os
+import json
 
 
-class FICGithub(FICLogger):
+class FICGithub(FICFileHandler, FICDataVault):
     def __init__(self):
-        FICLogger.__init__(self)
+        FICFileHandler.__init__(self)
+        FICDataVault.__init__(self)
         self.token_counter = 0
         self._get_os_var()
         self._token = os.environ.get(GIT_TOKEN[self.token_counter])
@@ -117,3 +120,6 @@ class FICGithub(FICLogger):
 
     def get_repo_url(self):
         return self.repo_data.svn_url
+
+    def _repo_team(self):
+        self.team_name = json.load(self.load(None, "repositories.json")).get("Github").get(self.repo_name).get("team")

--- a/modules/FIC_Github.py
+++ b/modules/FIC_Github.py
@@ -133,3 +133,6 @@ class FICGithub(FICFileHandler, FICDataVault):
 
     def _local_version(self):
         self.local_version = json.load(self.load(CHANGELOG_REPO_PATH, self.repo_name.lower() + ".json")).get("0").get("last_release").get("version")
+
+    def _last_checked(self):
+        self.last_check = json.load(self.load(CHANGELOG_REPO_PATH, self.repo_name.lower() + ".json")).get("0").get("last_checked")

--- a/modules/FIC_Github.py
+++ b/modules/FIC_Github.py
@@ -150,11 +150,8 @@ class FICGithub(FICFileHandler, FICDataVault):
                 return True
 
     def _compare_versions(self):
-        if self.build_puppet_version == self.release_version:
-            if self.release_version != self.local_version:
-                return True
-            else:
-                return False
+        if self.build_puppet_version == self.release_version and self.release_version != self.local_version:
+            return True
         else:
             return False
 
@@ -219,9 +216,8 @@ class FICGithub(FICFileHandler, FICDataVault):
                                                           'files': self.commit_files_changed}})
 
     def _commit_filter(self):
-        if self.repo_type == "commit-keyword":
-            if self.keyword in self.commit_message:
-                return True
+        if self.repo_type == "commit-keyword" and self.keyword in self.commit_message:
+            return True
 
         elif self.repo_type == "tag":
             if self.repo_name == "build-puppet":
@@ -247,9 +243,8 @@ class FICGithub(FICFileHandler, FICDataVault):
     def _tag(self):
         self._last_checked()
         self._get_release()
-        if self.repo_name == "mozapkpublisher":
-            if self.release_version != self.local_version:
-                self._commit_iterator()
+        if self.repo_name == "mozapkpublisher" and self.release_version != self.local_version:
+            self._commit_iterator()
         else:
             self._build_puppet_version()
             if self._compare_versions():

--- a/modules/FIC_Github.py
+++ b/modules/FIC_Github.py
@@ -49,7 +49,6 @@ class FICGithub(FICFileHandler, FICDataVault):
 
     def limit_checker(self):
         limit_requests = self._gh.ratelimit_remaining
-
         if limit_requests < 5 and len(GIT_TOKEN) > 1:
             # switch token
             if self._switch_token():
@@ -161,21 +160,21 @@ class FICGithub(FICFileHandler, FICDataVault):
     def _commit_iterator(self):
         self.commit_number = 0
         for current_commit in self.repo_data.commits(since=self.last_check):
-            self._get_message(current_commit)
-            if self._commit_filter():
-                self.commit_number += 1
-                self._store_data(current_commit)
-                self._construct_commit()
+            if self.limit_checker():
+                self._get_message(current_commit)
+                self._get_sha(current_commit)
+                self._get_files()
+                if self._commit_filter():
+                    self.commit_number += 1
+                    self._store_data(current_commit)
+                    self._construct_commit()
         self.keyword = None
 
     def _store_data(self, current_commit):
-        self._get_sha(current_commit)
-        self._get_message(current_commit)
         self._get_date(current_commit)
         self._get_author(current_commit)
         self._get_author_email(current_commit)
         self._get_url(current_commit)
-        self._get_files()
 
     def _get_sha(self, commit):
         self.commit_sha = commit.sha

--- a/modules/FIC_Github.py
+++ b/modules/FIC_Github.py
@@ -186,3 +186,12 @@ class FICGithub(FICFileHandler, FICDataVault):
             for changed_folder in range(len(self.commit_files_changed)):
                 if str(self.folders_to_check[folder_to_check]) in str(self.commit_files_changed[changed_folder]):
                     return True
+
+    def _construct_commit(self):
+        self.list_of_commits.update({self.commit_number: {'sha': self.commit_sha,
+                                                          'url': self.commit_url,
+                                                          'author': self.commit_author,
+                                                          'author_email': self.commit_author_email,
+                                                          'message': self.commit_message,
+                                                          'date': self.commit_date,
+                                                          'files': self.commit_files_changed}})

--- a/modules/FIC_Github.py
+++ b/modules/FIC_Github.py
@@ -5,6 +5,7 @@ import github3
 from modules.FIC_FileHandler import FICFileHandler
 from modules.FIC_DataVault import FICDataVault
 from modules.config import GIT_TOKEN
+from modules.config import CHANGELOG_REPO_PATH
 from git import Repo
 import os
 import json
@@ -130,3 +131,5 @@ class FICGithub(FICFileHandler, FICDataVault):
     def _extract_repo_type(self):
         self.repo_type = json.load(self.load(None, "repositories.json")).get("Github").get(self.repo_name).get("configuration").get("type")
 
+    def _local_version(self):
+        self.local_version = json.load(self.load(CHANGELOG_REPO_PATH, self.repo_name.lower() + ".json")).get("0").get("last_release").get("version")

--- a/repositories.json
+++ b/repositories.json
@@ -3,7 +3,7 @@
     "OpenCloudConfig": {
       "name": "Open Cloud Config",
       "url": "https://github.com/mozilla-releng/OpenCloudConfig",
-      "team": "mozilla-releng/",
+      "team": "mozilla-releng",
       "top-contributors": [" ", " "],
       "order": 7,
       "configuration": {
@@ -14,7 +14,7 @@
     "build-cloud-tools": {
       "name": "Build Cloud Tools",
       "url": "https://github.com/mozilla-releng/build-cloud-tools",
-      "team": "mozilla-releng/",
+      "team": "mozilla-releng",
       "top-contributors": [" ", " "],
       "order": 25,
       "configuration": {
@@ -25,7 +25,7 @@
     "taskcluster": {
       "name": "Taskcluster",
       "url": "https://github.com/taskcluster/taskcluster",
-      "team": "taskcluster/",
+      "team": "taskcluster",
       "top-contributors": [" ", " "],
       "order": 13,
       "configuration": {
@@ -36,7 +36,7 @@
     "services": {
       "name": "Release Services",
       "url": "https://github.com/mozilla/release-services",
-      "team": "mozilla/",
+      "team": "mozilla",
       "top-contributors": [" ", " "],
       "order": 24,
       "configuration": {
@@ -51,7 +51,7 @@
     "build-puppet": {
       "name": "Build Puppet",
       "url": "https://github.com/mozilla/build-puppet",
-      "team": "mozilla-releng/",
+      "team": "mozilla-releng",
       "order": 12,
       "configuration": {
         "type": "tag",
@@ -74,7 +74,7 @@
     "mozapkpublisher": {
       "name": "MozAPK Publisher",
       "url": "https://github.com/mozilla-releng/mozapkpublisher",
-      "team": "mozilla-releng/",
+      "team": "mozilla-releng",
       "top-contributors": [" ", " "],
       "order": 28,
       "configuration": {
@@ -86,7 +86,7 @@
     "beetmoverscript": {
       "name": "Beetmover Script",
       "url": "https://github.com/mozilla-releng/beetmoverscript",
-      "team": "mozilla-releng/",
+      "team": "mozilla-releng",
       "top-contributors": [" ", " "],
       "order": 14,
       "configuration": {
@@ -98,7 +98,7 @@
     "addonscript": {
       "name": "Addon Script",
       "url": "https://github.com/mozilla-releng/addonscript",
-      "team": "mozilla-releng/",
+      "team": "mozilla-releng",
       "top-contributors": [" ", " "],
       "order": 15,
       "configuration": {
@@ -110,7 +110,7 @@
     "shipitscript": {
       "name": "Shipit Script",
       "url": "https://github.com/mozilla-releng/shipitscript",
-      "team": "mozilla-releng/",
+      "team": "mozilla-releng",
       "top-contributors": [" ", " "],
       "order": 18,
       "configuration": {
@@ -122,7 +122,7 @@
     "bouncerscript": {
       "name": "Bouncer Script",
       "url": "https://github.com/mozilla-releng/bouncerscript",
-      "team": "mozilla-releng/",
+      "team": "mozilla-releng",
       "top-contributors": [" ", " "],
       "order": 19,
       "configuration": {
@@ -134,7 +134,7 @@
     "treescript": {
       "name": "Tree Script",
       "url": "https://github.com/mozilla-releng/treescript",
-      "team": "mozilla-releng/",
+      "team": "mozilla-releng",
       "top-contributors": [" ", " "],
       "order": 21,
       "configuration": {
@@ -146,7 +146,7 @@
     "scriptworker": {
       "name": "Script Worker",
       "url": "https://github.com/mozilla-releng/scriptworker",
-      "team": "mozilla-releng/",
+      "team": "mozilla-releng",
       "top-contributors": [" ", " "],
       "order": 20,
       "configuration": {
@@ -158,7 +158,7 @@
     "pushsnapscript": {
       "name": "Pushsnap Script",
       "url": "https://github.com/mozilla-releng/pushsnapscript",
-      "team": "mozilla-releng/",
+      "team": "mozilla-releng",
       "top-contributors": [" ", " "],
       "order": 16,
       "configuration": {
@@ -170,7 +170,7 @@
     "signingscript": {
       "name": "Signing Script",
       "url": "https://github.com/mozilla-releng/signingscript",
-      "team": "mozilla-releng/",
+      "team": "mozilla-releng",
       "top-contributors": [" ", " "],
       "order": 22,
       "configuration": {
@@ -182,7 +182,7 @@
     "pushapkscript": {
       "name": "Pushapk Script",
       "url": "https://github.com/mozilla-releng/pushapkscript",
-      "team": "mozilla-releng/",
+      "team": "mozilla-releng",
       "top-contributors": [" ", " "],
       "order": 17,
       "configuration": {
@@ -194,7 +194,7 @@
     "balrogscript": {
       "name": "Balrog Script",
       "url": "https://github.com/mozilla-releng/balrogscript",
-      "team": "mozilla-releng/",
+      "team": "mozilla-releng",
       "top-contributors": [" ", " "],
       "order": 11,
       "configuration": {
@@ -206,7 +206,7 @@
     "signtool": {
       "name": "Signtool",
       "url": "https://github.com/mozilla-releng/signtool",
-      "team": "mozilla-releng/",
+      "team": "mozilla-releng",
       "top-contributors": [" ", " "],
       "order": 23,
       "configuration": {
@@ -218,7 +218,7 @@
     "relops-image-builder": {
       "name": "Relops-Image-Builder",
       "url": "https://github.com/mozilla-platform-ops/relops-image-builder",
-      "team": "mozilla-platform-ops/",
+      "team": "mozilla-platform-ops",
       "top-contributors": [" ", " "],
       "order": 6,
       "configuration": {
@@ -229,7 +229,7 @@
     "relops-hardware-controller": {
       "name": "Relops-Hardware-Controller",
       "url": "https://github.com/mozilla-platform-ops/relops-hardware-controller",
-      "team": "mozilla-platform-ops/",
+      "team": "mozilla-platform-ops",
       "top-contributors": [" ", " "],
       "order": 8,
       "configuration": {
@@ -240,7 +240,7 @@
     "ronin_puppet": {
       "name": "Ronin-Puppet",
       "url": "https://github.com/mozilla-platform-ops/ronin_puppet",
-      "team": "mozilla-platform-ops/",
+      "team": "mozilla-platform-ops",
       "top-contributors": [" ", " "],
       "order": 9,
       "configuration": {


### PR DESCRIPTION
This PR will:
-----
- Finished all base functionality explained in Issue #438 -> filter the commits depending of repository type, repository version, repository files that affect CI and keywords.

Public methods:
======
FICGithub().start():                  https://github.com/mozilla-releng/firefox-infra-changelog/pull/448/commits/bf48b7609f0baff69110c2a2891c096b2d2eba6e
----
- I have implemented start() public method, the main method to call after the attribute repo_name is initialized in FICDataVault. The method will return a dictionary containing all the new commits that could affect the infrastructure. 

How to use:
---------
- for all Github repositories:
```python
construct = FICGithub()
for repo in json.load(construct.load(None, "repositories.json")).get("Github"):
    construct.repo_name = repo
    construct.start()
```
- only for one repository
```python
construct = FICGithub()
construct.repo_name = "pushapkscript"
construct.start()
```
it returns:
---
```python
pushapkscript
{1: 
   {'sha': 'a46ca21b8f0fc58058f448efe9f10d9ebbd63765', 
    'url': 'https://api.github.com/repos/mozilla-releng/pushapkscript/commits/a46ca21b8f0fc58058f448efe9f10d9ebbd63765', 
    'author': 'Mitchell Hentges', 
    'author_email': 'mhentges@mozilla.com', 
    'message': '1.0.3', 
    'date': '2019-05-07T20:30:46Z', 
    'files': ['version.txt']}}
```

FICGithub().get_repo_url():    https://github.com/mozilla-releng/firefox-infra-changelog/pull/448/commits/7db3e7e3392078d8ed7861ebde9075583959ad41
--------
- method that return the URL of the repository

Private methods:
======
self._repo_team():         https://github.com/mozilla-releng/firefox-infra-changelog/pull/448/commits/a1174b56ed252b102c0d0b666dc67ccd9750f6cf
------
- initialize self.team_name attribute with the owner/team of the repository.    

self._repo_files():         https://github.com/mozilla-releng/firefox-infra-changelog/pull/448/commits/dc752cc5d303ef1e8d1daa507a44654cce27d073
-----
- initialize self.folders_to_check  attribute with the folders-to-check from repositories.json

self._extract_repo_type():          https://github.com/mozilla-releng/firefox-infra-changelog/pull/448/commits/75148feebea8ce95ecc9585d73b1fb250650c0fb
------
- initialize self.repo_type attribute with the type of the repository

self._local_version():        https://github.com/mozilla-releng/firefox-infra-changelog/pull/448/commits/1d1ef280fdee399cb380c3dbc0a8c858efe31b23
------
- initialize self.local_version attribute with the version stored into the element 0 from .json file

self._get_release():       https://github.com/mozilla-releng/firefox-infra-changelog/pull/448/commits/514b36519fb39bba662c2dd2ec2b3d8031f539d2
---------
- initialize self.release_version attribute with the tag from the remote repository

self._get_version_path() and self._build_puppet_version(): https://github.com/mozilla-releng/firefox-infra-changelog/pull/448/commits/1cf960211b835317360c7455d4bdb9b9df27dc03
------
- initialize self.build_puppet_version attribute with the version from build-puppet for the scriptworkers

self._compare_versions():       https://github.com/mozilla-releng/firefox-infra-changelog/pull/448/commits/1cf960211b835317360c7455d4bdb9b9df27dc03
------
- returns True if the release version is equal with the version from build-puppet and if those are higher than the local version

self._last_checked():         https://github.com/mozilla-releng/firefox-infra-changelog/pull/448/commits/708a42cde62b3a3fd00f16dcbc83892ff020cae6
-----
- initialize self.last_check attribute with the datetime from element0/.json file

self._commit_iterator():    https://github.com/mozilla-releng/firefox-infra-changelog/pull/448/commits/353bc86ff25ec7525030c901119f87436705fe1f
-------
- iterates through the commits of the current repository

self._store_data():, self._get_sha():, self._get_message():, self. _get_date():,  self._get_author():, self._get_author_email():, self._get_url():,  self._get_files():             https://github.com/mozilla-releng/firefox-infra-changelog/pull/448/commits/353bc86ff25ec7525030c901119f87436705fe1f
------
- initialize all the commit information

self._compare_files():        https://github.com/mozilla-releng/firefox-infra-changelog/pull/448/commits/839dc589e2a9c0c5675f3db748b748798c29d45f
-------
- check if the changed files are affecting the infrastructure

self._construct_commit():             https://github.com/mozilla-releng/firefox-infra-changelog/pull/448/commits/1b6010573b4c106cb382214594064749e62df2a7
-------
- append the commit to the self.list_of_commits dictionary

self._commit_filter():               https://github.com/mozilla-releng/firefox-infra-changelog/pull/448/commits/a187b3e342f20591d00b6488f1258b612a3bd7f5
---------
- this method saves only the commits we care about: the commits that contain "deploy" or the release_version in the message, the commits that change the CI's files or the all commits for the repositories that requires this

 self._repo_switcher():          https://github.com/mozilla-releng/firefox-infra-changelog/pull/448/commits/981b869dbf93c29e818e8d2fdf59e303298d14b6
--------------
- distributes the repositories depending of their type
 - self._not_tag():, self._build_puppet():, self._tag():, self._commit_keyword():


For testing you can use the following patch:
========

[issue-438-1.txt](https://github.com/mozilla-releng/firefox-infra-changelog/files/3160320/issue-438-1.txt)


