### PR TITLE
Issue 449 - update the Git json files 

### DIFF
--- a/modules/FIC_FileHandler.py
+++ b/modules/FIC_FileHandler.py
@@ -93,7 +93,7 @@ class FICFileHandler(FICLogger, FICDataVault):
         for file_to_create in self._missing_files:
             new_local_file = open(self.construct_path(CHANGELOG_REPO_PATH, file_to_create[0].lower()), "w")
             if file_to_create[1] == "git" and file_to_create[0].endswith(".json"):
-                self.save(CHANGELOG_REPO_PATH, file_to_create[0], self._generate_first_element_git())
+                self.save(CHANGELOG_REPO_PATH, file_to_create[0], self._generate_first_element_git(self.repo_type))
             elif file_to_create[1] == "hg" and file_to_create[0].endswith(".json"):
                 self.save(CHANGELOG_REPO_PATH, file_to_create[0], self._generate_first_element_hg())
             new_local_file.close()

--- a/modules/FIC_FileHandler.py
+++ b/modules/FIC_FileHandler.py
@@ -101,7 +101,7 @@ class FICFileHandler(FICLogger, FICDataVault):
     def _generate_first_element_git(self, repo_type=None):
         repo_type = repo_type if repo_type else self._extract_repo_type()
         if repo_type == "tag":
-            return {"0": {"last_checked": return_time("%Y-%m-%dT%H:%M:%S.%f", "sub", 2), "version": self.local_version}}
+            return {"0": {"last_checked": return_time("%Y-%m-%dT%H:%M:%S.%f", "sub", 2), "version": self._get_release(2)}}
         else:
             return {"0": {"last_checked": return_time("%Y-%m-%dT%H:%M:%S.%f", "sub", 2)}}
 

--- a/modules/FIC_FileHandler.py
+++ b/modules/FIC_FileHandler.py
@@ -6,7 +6,6 @@ from modules.FIC_DataVault import FICDataVault
 from modules.config import *
 import json
 import os
-from modules.FIC_Utilities import return_time
 
 
 class FICFileHandler(FICLogger, FICDataVault):
@@ -92,24 +91,9 @@ class FICFileHandler(FICLogger, FICDataVault):
     def _create_missing_repo_files(self):
         for file_to_create in self._missing_files:
             new_local_file = open(self.construct_path(CHANGELOG_REPO_PATH, file_to_create[0].lower()), "w")
-            if file_to_create[1] == "git" and file_to_create[0].endswith(".json"):
-                self.save(CHANGELOG_REPO_PATH, file_to_create[0], self._generate_first_element_git(self.repo_type))
-            elif file_to_create[1] == "hg" and file_to_create[0].endswith(".json"):
-                self.save(CHANGELOG_REPO_PATH, file_to_create[0], self._generate_first_element_hg())
+            if file_to_create[0].endswith(".json"):
+                self.save(CHANGELOG_REPO_PATH, file_to_create[0].lower(), {})
             new_local_file.close()
-
-    def _generate_first_element_git(self, repo_type=None):
-        repo_type = repo_type if repo_type else self._extract_repo_type()
-        if repo_type == "tag":
-            return {"0": {"last_checked": return_time("%Y-%m-%dT%H:%M:%S.%f", "sub", 2), "version": self._get_release(2)}}
-        else:
-            return {"0": {"last_checked": return_time("%Y-%m-%dT%H:%M:%S.%f", "sub", 2)}}
-
-    def _generate_first_element_hg(self):
-        return {"0": {"last_push_id": "2019-04-12"}}
-
-    def _extract_repo_type(self):
-        return json.load(self.load(None, "repositories.json")).get("Github").get(self.repo_name).get("configuration").get("type")
 
     def _check_module_files(self):
         self._missing_files = []

--- a/modules/FIC_Github.py
+++ b/modules/FIC_Github.py
@@ -242,6 +242,7 @@ class FICGithub(FICFileHandler, FICDataVault):
     def _tag(self):
         self._last_checked()
         self._get_release()
+        self._local_version()
         if self.repo_name == "mozapkpublisher" and self.release_version != self.local_version:
             self._commit_iterator()
         else:

--- a/modules/FIC_Github.py
+++ b/modules/FIC_Github.py
@@ -135,8 +135,8 @@ class FICGithub(FICFileHandler, FICDataVault):
     def _local_version(self):
         self.local_version = json.load(self.load(CHANGELOG_REPO_PATH, self.repo_name.lower() + ".json")).get("0").get("last_release").get("version")
 
-    def _get_release(self):
-        self.release_version = [tag for tag in self.repo_data.tags(number=1)][0].name
+    def _get_release(self, release_number):
+        return [tag for tag in self.repo_data.tags(number=release_number)][release_number - 1].name
 
     def _get_version_path(self):
         self.version_path = json.load(self.load(None, "repositories.json")).get("Github").get(self.repo_name).get("configuration").get("version-path")
@@ -241,7 +241,7 @@ class FICGithub(FICFileHandler, FICDataVault):
 
     def _tag(self):
         self._last_checked()
-        self._get_release()
+        self.release_version = self._get_release(1)
         self._local_version()
         if self.repo_name == "mozapkpublisher" and self.release_version != self.local_version:
             self._commit_iterator()


### PR DESCRIPTION
- This PR will implement the functionality to update the GIT .json files with the new commits , the last check date time and the last release version.
- The .json files have the following structure:
  - last check and latest version
  - the commits, starting with the newest at the top of .json

_get-release() - https://github.com/mozilla-releng/firefox-infra-changelog/commit/86704202c9a3397bcadf2e48690362b42c6933b4
-----
This commit changes the method to return a release version of our choosing by accepting an integer argument. If the argument is "1" it will return the latest version, "2" will return the second to latest version, and so on

_generate_first_element() - https://github.com/mozilla-releng/firefox-infra-changelog/commit/72e30c75764df11e7f1f8e1567397bd47b8c5ee3
-------
This method will generate the element 0 for the .json files. It will contain the last check date and the last official release.

_write_git_json() - https://github.com/mozilla-releng/firefox-infra-changelog/commit/72e30c75764df11e7f1f8e1567397bd47b8c5ee3
--------
This method will update the .json files.  It will fuse the first element, the new commit dictionary and the old commit dictionary all in one and call the save function to write the .json. 
