### PR TITLE
Issue 454 - fix the indentation issues in the _commit_filter() method

### DIFF
--- a/modules/FIC_Github.py
+++ b/modules/FIC_Github.py
@@ -225,8 +225,9 @@ class FICGithub(FICFileHandler, FICDataVault):
                                                           'files': self.commit_files_changed}})
 
     def _commit_filter(self):
-        if self.repo_type == "commit-keyword" and self.keyword in self.commit_message:
-            return True
+        if self.repo_type == "commit-keyword":
+            if self.keyword in self.commit_message:
+                return True
 
         elif self.repo_type == "tag":
             if self.repo_name == "build-puppet":
@@ -235,8 +236,9 @@ class FICGithub(FICFileHandler, FICDataVault):
             elif self.release_version in self.commit_message:
                 return True
 
-        elif len(self.folders_to_check) > 0 and self._compare_files():
-            return True
+        elif len(self.folders_to_check) > 0:
+            if self._compare_files():
+                return True
 
         else:
             return True


### PR DESCRIPTION
This PR will fix the Issue #454 
====
In this case the method returns '0 == False' in case of the commit message not contain the keyword.
```python
228   if self.repo_type == "commit-keyword":
229       if self.keyword in self.commit_message:
230             return True
```
------
The method returns '0' if the repository is not build-puppet or if the commit message not contain the release_version.
```python 
232        elif self.repo_type == "tag":
233            if self.repo_name == "build-puppet":
234                return True
235
236            elif self.release_version in self.commit_message:
237                return True
```
-----
The following condition block returns '0' if the changed files are not affecting the infra.
```python
239        elif len(self.folders_to_check) > 0:
240            if self._compare_files():
241                return True
```
------
In case of a repository with no commit filters ( e.g taskcluster), the method returns 'True' for each commit.