### PR TITLE
Add improvements to FIC_Mercurial.py

### DIFF
--- a/modules/FIC_Mercurial.py
+++ b/modules/FIC_Mercurial.py
@@ -138,7 +138,7 @@ class FICMercurial(FICFileHandler, FICDataVault):
                                                                                            "commiter_message": commit_message,
                                                                                            "files_changed": self.commit_files_changed}})
 
-            if len(self.final_dict[push_number]["changeset_commits"]) == 0:
+            if self.final_dict[push_number]["changeset_commits"]:
                 del self.final_dict[push_number]
 
         #return self.final_dict

--- a/modules/FIC_Mercurial.py
+++ b/modules/FIC_Mercurial.py
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 from modules.FIC_FileHandler import FICFileHandler
 from modules.FIC_DataVault import FICDataVault
+from modules.FIC_Utilities import return_time
 import json
 import requests
 from modules.config import CHANGELOG_REPO_PATH
@@ -70,6 +71,7 @@ class FICMercurial(FICFileHandler, FICDataVault):
     # Using previous data generates a download link
     def _generate_push_link(self):
         if self.local_repo_data.get("0"):
+            self._get_last_local_push_id()
             url_options = "json-pushes?version=2&full=1&startID={}&endID={}".format(self.last_local_push_id, self.end_id)
         else:
             url_options = "json-pushes?version=2&full=1&startID={}&endID={}".format(self.end_id - 100, self.end_id)
@@ -88,8 +90,7 @@ class FICMercurial(FICFileHandler, FICDataVault):
 
     # Picks up date and formats it
     def _generate_changeset_date(self, date):
-        import time
-        self.changeset_date = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(date))
+        self.changeset_date = return_time("%Y-%m-%dT%H:%M:%S.%f")
         return self.changeset_date
 
     # Generated commit url by triming hash
@@ -126,3 +127,8 @@ class FICMercurial(FICFileHandler, FICDataVault):
                                                                                        "files_changed": files_changed}})
         #return self.final_dict
         self.save(CHANGELOG_REPO_PATH, self.repo_name + ".json", self.final_dict)
+
+
+FICFileHandler().check_tool_integrity()
+a = FICMercurial()
+a.start_hg("autoland")

--- a/modules/FIC_Mercurial.py
+++ b/modules/FIC_Mercurial.py
@@ -104,8 +104,9 @@ class FICMercurial(FICFileHandler, FICDataVault):
         self.final_dict = {}
         push_number = 0
         self.final_dict.update({"0": {"last_push_id": self.end_id}})
-        self.final_dict.update(self.local_repo_data)
-        push_number = len(self.final_dict) - 1
+        if len(self.local_repo_data):
+            self.final_dict.update(self.local_repo_data)
+            push_number = len(self.final_dict) - 1
         for push in self.changesets_json.get("pushes"):
             push_number += 1
             unformated_date = self.changesets_json.get("pushes").get(push).get("date")
@@ -127,8 +128,3 @@ class FICMercurial(FICFileHandler, FICDataVault):
                                                                                        "files_changed": files_changed}})
         #return self.final_dict
         self.save(CHANGELOG_REPO_PATH, self.repo_name + ".json", self.final_dict)
-
-
-FICFileHandler().check_tool_integrity()
-a = FICMercurial()
-a.start_hg("autoland")

--- a/modules/FIC_Mercurial.py
+++ b/modules/FIC_Mercurial.py
@@ -18,8 +18,8 @@ class FICMercurial(FICFileHandler, FICDataVault):
         self.repo_name = repo_name
         self.file_name = repo_name + ".json"
         self.folders_to_check = self._repo_files()
-        self.repo_data = json.load(open(self.construct_path(None, "repositories.json")))
-        self.local_repo_data = json.load(open(self.construct_path(CHANGELOG_REPO_PATH, self.file_name)))
+        self.repo_data = json.load(self.load(None, "repositories.json"))
+        self.local_repo_data = json.load(self.load(CHANGELOG_REPO_PATH, self.file_name))
         self._prepare_url()
         self._download_data()
         self._store_data()
@@ -137,5 +137,9 @@ class FICMercurial(FICFileHandler, FICDataVault):
                                                                                            "commiter_author": commit_author,
                                                                                            "commiter_message": commit_message,
                                                                                            "files_changed": self.commit_files_changed}})
+
+            if len(self.final_dict[push_number]["changeset_commits"]) == 0:
+                del self.final_dict[push_number]
+
         #return self.final_dict
         self.save(CHANGELOG_REPO_PATH, self.repo_name + ".json", self.final_dict)

--- a/modules/FIC_Mercurial.py
+++ b/modules/FIC_Mercurial.py
@@ -17,17 +17,13 @@ class FICMercurial(FICFileHandler, FICDataVault):
         self.repo_name = repo_name
         self.file_name = repo_name + ".json"
         self.repo_data = json.load(open(self.construct_path(None, "repositories.json")))
-        self.is_present = self.is_writable("data", repo_name + ".json")
-        if self.is_present:
-            self.local_repo_data = json.load(open(self.construct_path(CHANGELOG_REPO_PATH, self.file_name)))
+        self.local_repo_data = json.load(open(self.construct_path(CHANGELOG_REPO_PATH, self.file_name)))
         self._prepare_url()
         self._download_data()
         self._store_data()
 
     # =======PREPARE URL========
     def _prepare_url(self):
-        if self.is_present:
-            self._get_last_local_push_id()
         self._get_repo_link(self.repo_name)
         self._request_hg_data()
         self._load_response_in_json()
@@ -73,7 +69,7 @@ class FICMercurial(FICFileHandler, FICDataVault):
 
     # Using previous data generates a download link
     def _generate_push_link(self):
-        if self.is_present:
+        if self.local_repo_data.get("0"):
             url_options = "json-pushes?version=2&full=1&startID={}&endID={}".format(self.last_local_push_id, self.end_id)
         else:
             url_options = "json-pushes?version=2&full=1&startID={}&endID={}".format(self.end_id - 100, self.end_id)
@@ -107,9 +103,8 @@ class FICMercurial(FICFileHandler, FICDataVault):
         self.final_dict = {}
         push_number = 0
         self.final_dict.update({"0": {"last_push_id": self.end_id}})
-        if self.is_present:
-            self.final_dict.update(self.local_repo_data)
-            push_number = len(self.final_dict) - 1
+        self.final_dict.update(self.local_repo_data)
+        push_number = len(self.final_dict) - 1
         for push in self.changesets_json.get("pushes"):
             push_number += 1
             unformated_date = self.changesets_json.get("pushes").get(push).get("date")


### PR DESCRIPTION
This PR brings improvements to Mercurial part. 
Now, before running Mercurial part, the scrip will check if the expected final product (.json file) is present in data folder and acts accordingly. If the file is present, the script will just append the newest commits if not it will create the file with the last 100 changesets.