### PR TITLE
[Mercurial] Code Improvements

### DIFF
--- a/modules/FIC_Core.py
+++ b/modules/FIC_Core.py
@@ -61,7 +61,7 @@ class FICCore(FICGithub, FICMercurial, FICFileHandler, FICLogger):
         # Describes the behavioral of the script that runs in hg only mode.
         print("Testing hg mode behavioral...")
 
-        for repo in json.load(self.load(None, "repositories.json")).get("HG"):
+        for repo in json.load(self.load(None, "repositories.json")).get("Mercurial"):
             self.start_hg(repo)
 
     def _run_custom_repos_behavior(self, user_repos):


### PR DESCRIPTION
This PR fixes issue #461 
#### Renamed parameter "HG" to "Mercurial", since that is how we saved it in repositories.json

#### Renamed `_repo_files` to `_repo_files_hg` because there was a name conflicts due to FIC_Github.py having a method with the same name

## Split `_repo_files_hg` into smaller methods and changed the logic of the flow to also write the changeset from newset to oldest into the json files: af52c9e

To achieve the above mentioned flow the following changes were implemented:
* removed `self.hg_commits_list` as it wasn't used after initiated
* `list_of_dicts` was added to hold all the changesets which will later be written to json
* `_get_local_data` updates `list_of_dicts` with the old(local) chagnesets
* `changeset_dict` was added. This will contain the filtered data of one changeset at a time. The data is added here by `_add_changeset_data` and `_add_commit_data`. Once complete this dict is added to `list_of_dicts`
* after the iterations `list_of_dicts` will contain every changeset from oldest to newest
* `_populate_final_dict` updates `final_dict` and makes sure it is ready to be written to json

This way the json will contain the first element, changesets from newest to oldest and every changeset will have a key attributed to it.
