### PR TITLE
Markdown generation for changelog.md and individual repos

### DIFF
--- a/modules/FIC_Core.py
+++ b/modules/FIC_Core.py
@@ -5,7 +5,7 @@ from modules.FIC_Mercurial import FICMercurial
 from modules.FIC_FileHandler import FICFileHandler
 from modules.FIC_Logger import FICLogger
 from plugins.FIC_Markdown import FICMarkdownGenerator
-from modules.config import CHANGELOG_REPO_PATH, CHANGELOG_JSON_PATH, CHANGELOG_MD_PATH
+from modules.config import CHANGELOG_REPO_PATH, CHANGELOG_JSON_PATH, CHANGELOG_MD_PATH, DEFAULT_DAYS
 from modules.FIC_Utilities import return_time
 
 
@@ -109,7 +109,7 @@ class FICCore(FICGithub, FICMercurial, FICFileHandler, FICLogger, FICMarkdownGen
                     changelog["Mercurial"][key].update({commit_number: value})
                     commit_number += 1
 
-    def populate_changelog_json(self, number_of_days=1):
+    def populate_changelog_json(self, number_of_days):
         changelog = {}
         changelog.update({"Github": {},
                           "Mercurial": {}})

--- a/modules/FIC_DataVault.py
+++ b/modules/FIC_DataVault.py
@@ -23,6 +23,7 @@ class FICDataVault:
         self.repo_name            = None
         self.team_name            = None
         self.last_check           = None
+        self.commit_reviewer      = None
 
         # HG Specific values
         self.changeset_index      = None

--- a/modules/FIC_FileHandler.py
+++ b/modules/FIC_FileHandler.py
@@ -146,9 +146,8 @@ class FICFileHandler(FICLogger, FICDataVault):
 
     def save(self, directory, file_name, content):
         if file_name.endswith(".md"):
-            with open(self.construct_path(directory, file_name), "w") as markdown_file:
-                markdown_file.write("## " + self.repos_container.upper() + "\n\n")
-                markdown_file.write(content + "\n\n")
+            with open(self.construct_path(directory, file_name), "a") as markdown_file:
+                markdown_file.write(content)
 
         elif file_name.endswith(".json"):
             with open(self.construct_path(directory, file_name), "w") as json_file:

--- a/modules/FIC_Github.py
+++ b/modules/FIC_Github.py
@@ -288,7 +288,8 @@ class FICGithub(FICFileHandler, FICDataVault):
         else:
             return {"0": {"last_checked": return_time("%Y-%m-%dT%H:%M:%S.%f")}}
 
-    def start_git(self):
+    def start_git(self, repo_name=None):
+        self.repo_name = repo_name
         self._extract_repo_type()
         self._repo_team()
         self.read_repo()

--- a/plugins/FIC_Markdown.py
+++ b/plugins/FIC_Markdown.py
@@ -4,31 +4,38 @@
 from modules.FIC_DataVault import FICDataVault
 from modules.FIC_FileHandler import FICFileHandler
 from modules.FIC_Utilities import return_time
-from modules.config import COMMIT_DESCRIPTION_LENGTH
+from modules.config import COMMIT_DESCRIPTION_LENGTH, CHANGELOG_REPO_PATH
+import json
 
 
 class FICMarkdownGenerator(FICFileHandler, FICDataVault):
     def __init__(self):
         FICFileHandler.__init__(self)
         FICDataVault.__init__(self)
-        self.changelog_table_header = None
+        self.md_ready_data = []
 
-    def _get_current_time(self):
-        return return_time()
+    @staticmethod
+    def _get_current_time():
+        return return_time(time_format="%Y-%m-%dT%H:%M:%S")
+
+    def _load_local_json_data(self):
+        return json.load(self.load(CHANGELOG_REPO_PATH, self.repo_name.lower() + ".json"))
+
+    def _build_initial_md_structure(self):
+        self.md_ready_data.append(self._create_repo_markdown_header())
+        self.md_ready_data.append(self._create_first_table_row())
 
     def _create_repo_markdown_header(self):
-        return self.repo_name + " MD table" + "\n" + "Generated on: {}".format(self._get_current_time())
+        return "## " + self.repo_name + " MD table" + "\n" + "Generated on: {}".format(self._get_current_time()) + "\n\n"
 
-    def _create_first_table_row(self):
+    @staticmethod
+    def _create_first_table_row():
         return "| Commit Number | Commiter | Commit Message | Commit Url | Date | \n" + \
-               "|:-----:|:-----:|:----------------------------------:|:------:|:----:| \n"
+               "|:-----:|:-----:|:----------------------------------:|:------:|:----:| \n\n"
 
     def md_table_row_builder(self):
         return "|" + str(self.commit_number) + "|" + self.commit_author + "|" + self.commit_message + \
                "|" + "[URL](" + self.commit_url + ")" + "|" + str(self.commit_date) + "\n"
-
-    def write_markdown(self, directory, file_name):
-        self.save(directory, file_name, "CONTENT HERE")
 
     def generate_link_for_bugs(self):
         import re
@@ -79,7 +86,35 @@ class FICMarkdownGenerator(FICFileHandler, FICDataVault):
             self.commit_message = self.commit_message[0:length] + ".. [continue reading](" + commit_link + ")"
         return self.commit_message
 
-    def filter_commit(self):
-        self.filter_strings()
-        self.trim_commit_description(self.commit_url)
-        self.generate_link_for_bugs()
+    def _populate_md_table(self):
+        local_json_data = self._load_local_json_data()
+        if len(local_json_data) > 0:
+            del local_json_data["0"]
+            self.commit_number = 1
+            for key in local_json_data:
+                self.commit_date = local_json_data.get(key).get("date")
+                if self.commit_date > return_time("%Y-%m-%dT%H:%M:%S", "sub", 7):
+                    self.commit_author = local_json_data.get(key).get("author")
+                    self.commit_url = local_json_data.get(key).get("url")
+                    self.commit_message = local_json_data.get(key).get("message")
+                    self.commit_author, self.commit_message = self.filter_strings()
+                    self.trim_commit_description(self.commit_url, COMMIT_DESCRIPTION_LENGTH)
+                    self.generate_link_for_bugs()
+                    self.md_ready_data.append(self.md_table_row_builder())
+                    self.commit_number += 1
+        else:
+            print("No commits in the past 7 days")  # to be replace with a method
+
+    def start_md_for_git(self, repo_name=None):
+        self.repo_name = repo_name
+        self._build_initial_md_structure()
+        self._populate_md_table()
+        for element in a.md_ready_data:
+            print(element)
+            a.save(CHANGELOG_REPO_PATH, a.repo_name + ".md", element)
+
+
+# TESTING BELOW
+
+a = FICMarkdownGenerator()
+a.start_md_for_git("taskcluster")

--- a/plugins/FIC_Markdown.py
+++ b/plugins/FIC_Markdown.py
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 from modules.FIC_DataVault import FICDataVault
 from modules.FIC_FileHandler import FICFileHandler
+from modules.FIC_Utilities import return_time
 from modules.config import COMMIT_DESCRIPTION_LENGTH
 
 
@@ -10,21 +11,19 @@ class FICMarkdownGenerator(FICFileHandler, FICDataVault):
     def __init__(self):
         FICFileHandler.__init__(self)
         FICDataVault.__init__(self)
-        FICFilters.__init__(self)
         self.changelog_table_header = None
 
     def _get_current_time(self):
-        import datetime
-        self._current_time = datetime.datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S UTC")
+        self._current_time = return_time()
         return self._current_time
 
-    def _create_repo_markdown_header(self, repo_name):
-        self.markdown_header = repo_name + " MD table" + "\n" + "Generated on: {}".format(self._current_time)
+    def _create_repo_markdown_header(self):
+        self.markdown_header = self.repo_name + " MD table" + "\n" + "Generated on: {}".format(self._current_time)
         return self.markdown_header
 
     def create_first_table_row(self):
         self.first_row_string = "| Commit Number | Commiter | Commit Message | Commit Url | Date | \n" + \
-                           "|:---:|:----:|:----------------------------------:|:------:|:----:| \n"
+                                "|:---:|:----:|:----------------------------------:|:------:|:----:| \n"
         return self.first_row_string
 
     def md_table_row_builder(self):

--- a/plugins/FIC_Markdown.py
+++ b/plugins/FIC_Markdown.py
@@ -104,7 +104,7 @@ class FICMarkdownGenerator(FICFileHandler, FICDataVault):
                     self.md_ready_data.append(self.md_table_row_builder())
                     self.commit_number += 1
         else:
-            print("No commits in the past 7 days")  # to be replace with a method
+            print("No commits in the past {} days".format(DEFAULT_DAYS))  # to be replace with a method
 
     def start_md_for_git(self, repo_name=None):
         self.repo_name = repo_name
@@ -201,6 +201,7 @@ class FICMarkdownGenerator(FICFileHandler, FICDataVault):
                     self.changelog_md_data.append(self._changelog_md_row_builder())
 
     def create_changelog_md(self):
+        open(self.construct_path(None, CHANGELOG_MD_PATH), 'w').close()
         changelog_data = json.load(self.load(None, CHANGELOG_JSON_PATH))
         repo_config = json.load(self.load(None, REPOSITORIES_FILE))
         repo_order = self._get_display_order(changelog_data, repo_config)

--- a/plugins/FIC_Markdown.py
+++ b/plugins/FIC_Markdown.py
@@ -31,7 +31,7 @@ class FICMarkdownGenerator(FICFileHandler, FICDataVault):
     @staticmethod
     def _create_first_table_row():
         return "| Commit Number | Commiter | Commit Message | Commit Url | Date | \n" + \
-               "|:-----:|:-----:|:----------------------------------:|:------:|:----:| \n\n"
+               "|:-----:|:-----:|:----------------------------------:|:------:|:----:| \n"
 
     def md_table_row_builder(self):
         return "|" + str(self.commit_number) + "|" + self.commit_author + "|" + self.commit_message + \

--- a/plugins/FIC_Markdown.py
+++ b/plugins/FIC_Markdown.py
@@ -109,12 +109,6 @@ class FICMarkdownGenerator(FICFileHandler, FICDataVault):
         self.repo_name = repo_name
         self._build_initial_md_structure()
         self._populate_md_table()
-        for element in a.md_ready_data:
-            print(element)
-            a.save(CHANGELOG_REPO_PATH, a.repo_name + ".md", element)
+        for element in self.md_ready_data:
+            self.save(CHANGELOG_REPO_PATH, a.repo_name + ".md", element)
 
-
-# TESTING BELOW
-
-a = FICMarkdownGenerator()
-a.start_md_for_git("taskcluster")

--- a/plugins/FIC_Markdown.py
+++ b/plugins/FIC_Markdown.py
@@ -14,22 +14,18 @@ class FICMarkdownGenerator(FICFileHandler, FICDataVault):
         self.changelog_table_header = None
 
     def _get_current_time(self):
-        self._current_time = return_time()
-        return self._current_time
+        return return_time()
 
     def _create_repo_markdown_header(self):
-        self.markdown_header = self.repo_name + " MD table" + "\n" + "Generated on: {}".format(self._current_time)
-        return self.markdown_header
+        return self.repo_name + " MD table" + "\n" + "Generated on: {}".format(self._get_current_time())
 
-    def create_first_table_row(self):
-        self.first_row_string = "| Commit Number | Commiter | Commit Message | Commit Url | Date | \n" + \
-                                "|:---:|:----:|:----------------------------------:|:------:|:----:| \n"
-        return self.first_row_string
+    def _create_first_table_row(self):
+        return "| Commit Number | Commiter | Commit Message | Commit Url | Date | \n" + \
+               "|:-----:|:-----:|:----------------------------------:|:------:|:----:| \n"
 
     def md_table_row_builder(self):
-        self.md_table_row = "|" + str(self.commit_number) + "|" + self.commit_author + "|" + self.commit_message + \
-                      "|" + "[URL](" + self.commit_url + ")" + "|" + str(self.commit_date) + "\n"
-        return self.md_table_row
+        return "|" + str(self.commit_number) + "|" + self.commit_author + "|" + self.commit_message + \
+               "|" + "[URL](" + self.commit_url + ")" + "|" + str(self.commit_date) + "\n"
 
     def write_markdown(self, directory, file_name):
         self.save(directory, file_name, "CONTENT HERE")


### PR DESCRIPTION
This PR fixes issue #414 
It handles the following:
* creation of individual MD files for every repo
* populates changelog.json
* creates changelog.md from changelog.json

### Creation of individual MD and changelog.md files both have an entry point:
`start_md_for_hg` and `start_md_for_git` and lastly `create_changelog_md`

The logic behind these is similar:
* they **_load_** the respective **_json file_** into an object
* a **_list_** will hold all the data to be written into the MD files
*  the **_structure of this list_** is: MD header + first table row  + each table row belonging to a commit
* each element of the **_completed list_** is **_appended_** to the proper MD file

For changelog.md a list of tupples was created. This helped with:
* sorting the repos into the order that we want them to be displayed
* figuring out if it is a git repo or a hg one

### Populating changelog.json happens as follows:
* iterating through every json file within the **_data_** folder
* extract the appropriate data and **_adds it to the main dict_** that is to be written into changelog.json
* added the option to **_select how many days of data_** we want to view