### PR TITLE
Removed/Updated unsused exit codes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ In the following table are the predefined exitcodes that script can generate:
 |:---------:|:-----------------------------------------------------:|:------------------------------------------------------------------:|
 |     2     |             File Extension not supported.             |               `save()` method from FIC_FileHandler.py              |
 |     3     |          The script failed to pull the dates.         |                                                                    |
-|     4     |  The -days/--days argument is not followed by an int. |                                                                    |
+|     4     |  The -days/--days argument is not followed by an int. |        `_set_arguments_flags()` method from FIC_MainMenu.py        |
 |     5     |           The provided file does not exist.           |            `file_size()` from modules.FIC_FileHandler.py           |
 |     6     |      Can't check file size for provided filename.     |        `file_size()` method from modules.FIC_FileHandler.py        |
 |     7     |                 Failed to rename file.                |      `rename_file_with_date()` from modules.FIC_FileHandler.py     |

--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ In the following table are the predefined exitcodes that script can generate:
 |     7     |                 Failed to rename file.                |      `rename_file_with_date()` from modules.FIC_FileHandler.py     |
 |     8     |     Access denied to read/write to provided file.     |       `is_readable()` method from modules.FIC_FileHandler.py       |
 |     10    |                  Keyboard interrupt.                  |      Used in `signal_handler()` from modules.FIC_Exceptions.py     |
-|     11    |           Provided input is not an integer.           |                                                                    |
 |     12    |              Unknown repository provider.             |   Used in `_run_custom_repos_behavior()` from modules.FIC_Core.py  |
 |     13    |                  Unknown Return Time.                 |          Used in `return_time()` from modules.Utilities.py         |
 |    301    |                   Moved Permanently                   | Defined in `handle_git_exception()` from modules.FIC_Exceptions.py |

--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ In the following table are the predefined exitcodes that script can generate:
 |     6     |      Can't check file size for provided filename.     |        `file_size()` method from modules.FIC_FileHandler.py        |
 |     7     |                 Failed to rename file.                |      `rename_file_with_date()` from modules.FIC_FileHandler.py     |
 |     8     |     Access denied to read/write to provided file.     |       `is_readable()` method from modules.FIC_FileHandler.py       |
-|     9     |          No git authentication tokens found.          |                                                                    |
 |     10    |                  Keyboard interrupt.                  |      Used in `signal_handler()` from modules.FIC_Exceptions.py     |
 |     11    |           Provided input is not an integer.           |                                                                    |
 |     12    |              Unknown repository provider.             |   Used in `_run_custom_repos_behavior()` from modules.FIC_Core.py  |
@@ -61,5 +60,3 @@ In the following table are the predefined exitcodes that script can generate:
 |    500    |                 Internal Server Error                 | Defined in `handle_git_exception()` from modules.FIC_Exceptions.py |
 |    501    |                    Not Implemented                    | Defined in `handle_git_exception()` from modules.FIC_Exceptions.py |
 |    503    |                  Service Unavailable                  | Defined in `handle_git_exception()` from modules.FIC_Exceptions.py |
-|           |                                                       |                                                                    |
-|           |                                                       |                                                                    |

--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ In the following table are the predefined exitcodes that script can generate:
 | Exit Code |                      Description                      |                              Used in:                              |
 |:---------:|:-----------------------------------------------------:|:------------------------------------------------------------------:|
 |     2     |             File Extension not supported.             |               `save()` method from FIC_FileHandler.py              |
-|     3     |          The script failed to pull the dates.         |                                                                    |
 |     4     |  The -days/--days argument is not followed by an int. |        `_set_arguments_flags()` method from FIC_MainMenu.py        |
 |     5     |           The provided file does not exist.           |            `file_size()` from modules.FIC_FileHandler.py           |
 |     6     |      Can't check file size for provided filename.     |        `file_size()` method from modules.FIC_FileHandler.py        |


### PR DESCRIPTION
Updated Exit Code 4 usage docs: 07678b0
Removed exit code 3 from documentation, not used here: 4c3ea18
Removed exit code 9 (not implemented) and the last two table row cells (empty cells): 67f954d
Removed exit code 11 from documentation, not implemented in OOP: 5bf9ae6