### PR TITLE
Add argument '-s' to skip the menu when the script runs on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ before_install:
 - echo $TRAVIS_REPO_SLUG
 script:
 - pip3 install -r requirements.txt
-- python3 client.py -a
+- python3 client.py -s -a


### PR DESCRIPTION
I've changed the .travis.yml file, by adding '-s' argument for skipping the main-menu when the script runs on Travis CI

![FIC-Travis](https://user-images.githubusercontent.com/35918050/60294812-ea4b7280-992a-11e9-89b5-c4f661c94cf1.JPG)
